### PR TITLE
ParseInt for validateCode

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -148,7 +148,7 @@ export class AugustPlatform implements DynamicPlatformPlugin {
       this.debugLog(superStringify(this.august));
       if (this.config.credentials?.validateCode) {
       // A 6-digit code will be sent to your email or phone (depending on what you used for your augustId). Send the code back:
-        this.august.validate(this.config.credentials.validateCode);
+        this.august.validate(parseInt(this.config.credentials.validateCode));
       } else {
         // If this is the first time you're using this installId, you need to authorize and validate:
         this.august.authorize();


### PR DESCRIPTION
Parse validateCode as an integer. We could make the UI take in an integer, but then the user is presented with a number selector which isn't ideal. Easiest to keep it as a string in the UI and just parse it as an int on the backend.

## :recycle: Current situation

The Homebridge UI puts the verification code in the config as a string which causes an authentication error on august's servers. Changing it to an int works, but then you have to manually update the config. 

## :bulb: Proposed solution

Add parseInt before the code is sent to the server. This way both integer and string verification codes will work right with august's servers.

## :gear: Release Notes

Plugin now works correctly with string-based verification code configs.

### Testing

N/A