### PR TITLE
ParseInt validateCode

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -137,7 +137,7 @@ export class AugustPlatform implements DynamicPlatformPlugin {
       await this.augustCredentials();
       if (!this.config.credentials?.isValidated && this.config.credentials?.validateCode) {
         const validateCode = this.config.credentials?.validateCode;
-        const isValidated = await this.august.validate(validateCode);
+        const isValidated = await this.august.validate(parseInt(validateCode));
         // If validated successfully, set flag for future use, and you can now use the API
         this.config.credentials.isValidated = isValidated;
         // load in the current config


### PR DESCRIPTION
Parse validateCode as an integer. We could make the UI take in an integer, but then the user is presented with a number selector which isn't ideal. Easiest to keep it as a string in the UI and just parse it as an int on the backend.

## :recycle: Current situation

The Homebridge UI puts the verification code in the config as a string which causes an authentication error on august's servers. Changing it to an int works, but then you have to manually update the config. 

## :bulb: Proposed solution

Add parseInt before the code is sent to the server. This way both integer and string verification codes will work right with august's servers.

## :gear: Release Notes

Plugin now works correctly with string-based verification code configs.

### Testing

N/A