### PR TITLE
Fix 'Locking...' and 'Unlocking...' issue

### DIFF
--- a/src/devices/lock.ts
+++ b/src/devices/lock.ts
@@ -350,11 +350,13 @@ export class LockMechanism {
       if (!this.hide_lock) {
         if (AugustEvent.state.unlocked) {
           this.LockCurrentState = this.platform.Characteristic.LockCurrentState.UNSECURED;
+          this.LockTargetState = this.platform.Characteristic.LockCurrentState.UNSECURED;
           if (this.LockCurrentState !== this.accessory.context.LockCurrentState) {
             this.infoLog(`Lock: ${this.accessory.displayName} was Unlocked`);
           }
         } else if (AugustEvent.state.locked) {
           this.LockCurrentState = this.platform.Characteristic.LockCurrentState.SECURED;
+          this.LockTargetState = this.platform.Characteristic.LockCurrentState.SECURED;
           if (this.LockCurrentState !== this.accessory.context.LockCurrentState) {
             this.infoLog(`Lock: ${this.accessory.displayName} was Locked`);
           }


### PR DESCRIPTION
When a lock is unlocked or locked manually, the event is correctly sent to the plugin, and the current state is updated. The lock target state also needs to be updated to match the current state.

## :recycle: Current situation

As the Target state is not updated, it is stale, and reflects the last state of the lock. Which is often the opposite of the new Current state. So in the HomeKit UIs it will show that the lock is currently transitioning from the Current state to the Target state, and the UI will be stuck there until the user either uses HomeKit to change the lock state, or manually restores the lock to the previous state.

## :bulb: Proposed solution

When the event arrives that the user has manually changed the lock state, also update the Target lock state to match.

## :gear: Release Notes

Fixes issue https://github.com/donavanbecker/homebridge-august/issues/22 where manual lock changes result in Home app showing the lock stuck in transition mode.

### Testing

Manually tested on my Homebridge setup with two August Locks (AUG-SL04-M01-G04) that do not have DoorSense setup. Manual testing included:
* Manually changing lock state and checking that the UI updated correctly. 
* Changing the lock state in the Home app and checking that the UI updated correctly and the physical locks changed state. 
* Changing the lock state in the August app via Bluetooth, and checking that the UI updated correctly and the physical locks changed state 
* Changing the lock state in the August app via Bluetooth, and checking that the UI updated correctly and the physical locks changed state 

### Reviewer Nudging

Focus on when a lock state change happens externally to HomeKit.
