### PR TITLE
Fix debugging issue and reduce August API calls

### DIFF
--- a/src/devices/lock.ts
+++ b/src/devices/lock.ts
@@ -221,11 +221,11 @@ export class LockMechanism {
       if (lockDetails) {
         this.debugLog(`Lock: ${this.accessory.displayName} lockDetails (refreshStatus): ${superStringify(lockDetails)}`);
 		
-		// Get Lock Status (use August-api helper function to resolve state)
-		var lockStatus = lockDetails.LockStatus;
-		this.platform.august.addSimpleProps(lockStatus);
-		if (lockStatus.state && !this.hide_lock) {
-		  this.unlocked = lockStatus.state.unlocked;
+        // Get Lock Status (use August-api helper function to resolve state)
+        var lockStatus = lockDetails.LockStatus;
+        this.platform.august.addSimpleProps(lockStatus);
+        if (lockStatus.state && !this.hide_lock) {
+          this.unlocked = lockStatus.state.unlocked;
           this.state = lockStatus.state;
           this.locked = lockStatus.state.locked;
         }

--- a/src/devices/lock.ts
+++ b/src/devices/lock.ts
@@ -350,11 +350,13 @@ export class LockMechanism {
       if (!this.hide_lock) {
         if (AugustEvent.state.unlocked) {
           this.LockCurrentState = this.platform.Characteristic.LockCurrentState.UNSECURED;
+          this.LockTargetState = this.platform.Characteristic.LockCurrentState.UNSECURED;
           if (this.LockCurrentState !== this.accessory.context.LockCurrentState) {
             this.infoLog(`Lock: ${this.accessory.displayName} was Unlocked`);
           }
         } else if (AugustEvent.state.locked) {
           this.LockCurrentState = this.platform.Characteristic.LockCurrentState.SECURED;
+          this.LockTargetState = this.platform.Characteristic.LockCurrentState.SECURED;
           if (this.LockCurrentState !== this.accessory.context.LockCurrentState) {
             this.infoLog(`Lock: ${this.accessory.displayName} was Locked`);
           }

--- a/src/devices/lock.ts
+++ b/src/devices/lock.ts
@@ -345,7 +345,7 @@ export class LockMechanism {
   async subscribeAugust(): Promise<void> {
     await this.platform.augustCredentials();
     await this.platform.august.subscribe(this.device.lockId, (AugustEvent: any, timestamp: any) => {
-      this.debugLog(`Lock: ${this.accessory.displayName} AugustEvent: ${superStringify(AugustEvent), superStringify(timestamp)}`);
+      this.debugLog(`Lock: ${this.accessory.displayName} AugustEvent: ${superStringify(AugustEvent)}, ${superStringify(timestamp)}`);
       //LockCurrentState
       if (!this.hide_lock) {
         if (AugustEvent.state.unlocked) {

--- a/src/devices/lock.ts
+++ b/src/devices/lock.ts
@@ -222,7 +222,7 @@ export class LockMechanism {
         this.debugLog(`Lock: ${this.accessory.displayName} lockDetails (refreshStatus): ${superStringify(lockDetails)}`);
 		
 		// Get Lock Status (use August-api helper function to resolve state)
-		var lockStatus = lockDetails.lockStatus;
+		var lockStatus = lockDetails.LockStatus;
 		this.platform.august.addSimpleProps(lockStatus);
 		if (lockStatus.state && !this.hide_lock) {
 		  this.unlocked = lockStatus.state.unlocked;


### PR DESCRIPTION
## :recycle: Current situation

Two issues are reported:
https://github.com/donavanbecker/homebridge-august/issues/67 Multiple calls to August-API which is rate limited
https://github.com/donavanbecker/homebridge-august/issues/68 Debugging issue

## :bulb: Proposed solution

Minor fix for debugging so that it now dumps full JSON object
LockStatus is returned inside LockDetails. So rather than request Status and then Details, just request Details and use the Status object contained within it.
This does remove the ability to report if the lock is jammed - though this seems like a minor issue when compared to reducing the calls to the August API.

## :gear: Release Notes

https://github.com/donavanbecker/homebridge-august/issues/68 - Fully print the JSON object for AugustEvent when debugging is enabled.
https://github.com/donavanbecker/homebridge-august/issues/67 - Cut the number of calls to the August API in half for each lock.

## :heavy_plus_sign: Additional Information

Test the compilation of Typescript file and make sure it worked. I don't have a Typescript compiler so I make the changes in the generated lock.js file, and then copied the changes back to the .ts file. 

### Testing

Tested with AUG-SL04-M01-G04 without DoorSense using changes in lock.js file:
* manually locking and unlocking lock and checking state in Home app
* locking and unlocking lock in Home app and ensuring physical lock worked correctly
* locking and unlocking lock in Home app and checking the state in the August app

### Reviewer Nudging

Make sure it all compiles correctly to js, and that it functions. Or send me a copy of the .js file and I can validate it.
