### PR TITLE
Fix typo in initial setup message

### DIFF
--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -9,7 +9,7 @@
   <p class="lead text-center">To get started link your August Account:</p>
   <ol>
     <li class="mb-3">Input your August <strong>E-mail/Phone Number</strong> into the August Account Info.</li>
-    <li class="mb-3">Restart Homebrdige to receive an August <strong>Validate Code</strong>.</li>
+    <li class="mb-3">Restart Homebridge to receive an August <strong>Validate Code</strong>.</li>
     <li class="mb-3">Input your <strong>Validate Code</strong> into the August Account Info.</li>
     <li class="mb-3">Finally <strong>Restart</strong> Homebridge..</li>
   </ol>


### PR DESCRIPTION
## :recycle: Current situation

Initial setup text has "Homebridge" misspelled as "Homebrdige".

## :bulb: Proposed solution

Fix the typo.

## :gear: Release Notes

Fixes a typo in plugin setup text.