### PR TITLE
fix August validation failure with verification codes starting with 0

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -141,7 +141,7 @@ export class AugustPlatform implements DynamicPlatformPlugin {
       await this.augustCredentials();
       if (!this.config.credentials?.isValidated && this.config.credentials?.validateCode) {
         const validateCode = this.config.credentials?.validateCode;
-        const isValidated = await this.august.validate(parseInt(validateCode));
+        const isValidated = await this.august.validate(validateCode);
         // If validated successfully, set flag for future use, and you can now use the API
         this.config.credentials.isValidated = isValidated;
         // load in the current config


### PR DESCRIPTION
## :recycle: Current situation

If your August verification code starts with 0, the validation check fails. See issue #54 and #48.

## :bulb: Proposed solution

Don't call `parseInt()` on the user-supplied verification code, which can delete leading zeros. The August `validate()` API method wants a string anyways.

## :gear: Release Notes

Support verification codes with leading zeros (no breaking changes).

## :heavy_plus_sign: Additional Information

### Testing

### Reviewer Nudging

