### PR TITLE
update LockTargetState to match LockCurrentState during lock refresh

### DIFF
--- a/src/devices/lock.ts
+++ b/src/devices/lock.ts
@@ -192,11 +192,14 @@ export class LockMechanism extends deviceBase {
             : this.lockStatus.state.unlocked
               ? this.hap.Characteristic.LockCurrentState.UNSECURED
               : retryCount > 1 ? this.hap.Characteristic.LockCurrentState.JAMMED : this.hap.Characteristic.LockCurrentState.UNKNOWN
+          this.LockMechanism.LockTargetState = this.LockMechanism.LockCurrentState
+
           if (this.LockMechanism.LockCurrentState === this.hap.Characteristic.LockCurrentState.UNKNOWN) {
             await this.warnLog(`LockCurrentState: ${this.LockMechanism.LockCurrentState}, (UNKNOWN) parseStatus`
               + ` lockEvent: ${JSON.stringify(this.lockEvent)}`)
           }
           await this.debugLog(`LockCurrentState: ${this.LockMechanism.LockCurrentState}`)
+          await this.debugLog(`LockTargetState: ${this.LockMechanism.LockTargetState}`)
         }
         // Contact Sensor
         if (!this.device.lock?.hide_contactsensor && this.ContactSensor?.Service) {
@@ -261,11 +264,14 @@ export class LockMechanism extends deviceBase {
             : this.lockEvent.state.unlocked
               ? this.hap.Characteristic.LockCurrentState.UNSECURED
               : retryCount > 1 ? this.hap.Characteristic.LockCurrentState.JAMMED : this.hap.Characteristic.LockCurrentState.UNKNOWN
+          this.LockMechanism.LockTargetState = this.LockMechanism.LockCurrentState
+
           if (this.LockMechanism.LockCurrentState === this.hap.Characteristic.LockCurrentState.UNKNOWN) {
             await this.warnLog(`LockCurrentState: ${this.LockMechanism.LockCurrentState}, (UNKNOWN) parseEventStatus`
               + ` lockEvent: ${JSON.stringify(this.lockEvent)}`)
           }
           await this.debugLog(`LockCurrentState: ${this.LockMechanism.LockCurrentState}`)
+          await this.debugLog(`LockTargetState: ${this.LockMechanism.LockTargetState}`)
         }
         // Contact Sensor
         if (!this.device.lock?.hide_contactsensor && this.ContactSensor?.Service) {


### PR DESCRIPTION

## :recycle: Current situation

The LockTargetState attribute is not updated while polling/listening to events from the August API. This leads to any manual changes of the lock (ie I physically lock/unlock it) to cause the lock status to always show unlocking or locking in Homekit.

## :bulb: Proposed solution

Update the LockTargetState attribute to be the same value as the LockCurrentState during both polling or pushed events. This plugin used to operate with this logic around the 2.0.0 version and prior but somewhere after 2.0.0 this logic was changed.

## :gear: Release Notes

LockTargetState is updated for manual lock events

## :heavy_plus_sign: Additional Information


### Testing


### Reviewer Nudging

