### PR TITLE
Fix: Suppress spurious HomeKit notifications on startup

### DIFF
--- a/src/devices/device.test.ts
+++ b/src/devices/device.test.ts
@@ -1,4 +1,44 @@
+import type { CharacteristicValue, Service } from 'homebridge'
+
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Create a simplified test implementation that mimics the updateCharacteristic behavior
+class MockDeviceWithCharacteristics {
+  accessory = { context: {} as Record<string, CharacteristicValue>, displayName: 'Test Lock' }
+  debugLog = vi.fn()
+  debugWarnLog = vi.fn()
+  infoLog = vi.fn()
+
+  async updateCharacteristic(
+    Service: Service,
+    ServiceName: string,
+    Characteristic: any,
+    CharacteristicValue: CharacteristicValue,
+    CharacteristicName: string,
+    Value?: CharacteristicValue,
+    StatusMatch?: string,
+    StatusDoesNotMatch?: string,
+  ): Promise<void> {
+    if (CharacteristicValue === undefined) {
+      await this.debugLog(`${CharacteristicName}: ${CharacteristicValue}`)
+    } else {
+      const contextKey = `${ServiceName}${CharacteristicName}`
+      await this.debugWarnLog(`context before: ${this.accessory.context[contextKey]}`)
+      const contextBefore = this.accessory.context[contextKey]
+      this.accessory.context[contextKey] = CharacteristicValue
+      await this.debugWarnLog(`context after: ${this.accessory.context[contextKey]}`)
+      await this.debugLog(`updateCharacteristic ${CharacteristicName}: ${CharacteristicValue} (${CharacteristicValue === Value ? StatusMatch : StatusDoesNotMatch})`)
+      if (contextBefore !== CharacteristicValue) {
+        // Value actually changed - push update to HomeKit
+        Service.updateCharacteristic(Characteristic, CharacteristicValue)
+        // Only log state change messages when we had a prior known value (not initial discovery)
+        if (contextBefore !== undefined && StatusMatch && StatusDoesNotMatch) {
+          await this.infoLog(`was ${CharacteristicValue === Value ? StatusMatch : StatusDoesNotMatch}`)
+        }
+      }
+    }
+  }
+}
 
 // Create a simplified test implementation that mimics the statusCode behavior
 class MockDevice {
@@ -188,6 +228,141 @@ describe('statusCode error handling', () => {
 
       expect(mockDevice.debugLog).toHaveBeenCalledWith('Unknown statusCode: 503 Service Unavailable, Submit Bugs Here: https://tinyurl.com/AugustYaleBug')
       expect(mockDevice.debugErrorLog).toHaveBeenCalledWith('failed test action, Error: [object Object]')
+    })
+  })
+})
+
+describe('updateCharacteristic', () => {
+  let device: MockDeviceWithCharacteristics
+  let mockService: Service
+  const CHARACTERISTIC = 'LockCurrentState'
+
+  beforeEach(() => {
+    device = new MockDeviceWithCharacteristics()
+    mockService = {
+      updateCharacteristic: vi.fn(),
+    } as unknown as Service
+  })
+
+  it('should skip HomeKit update when CharacteristicValue is undefined', async () => {
+    await device.updateCharacteristic(mockService, 'LockMechanism', CHARACTERISTIC, undefined as any, 'LockCurrentState')
+
+    expect(mockService.updateCharacteristic).not.toHaveBeenCalled()
+    expect(device.debugLog).toHaveBeenCalledWith('LockCurrentState: undefined')
+  })
+
+  describe('initial state discovery (no prior context)', () => {
+    it('should push value to HomeKit on first update', async () => {
+      await device.updateCharacteristic(mockService, 'LockMechanism', CHARACTERISTIC, 0, 'LockCurrentState', 1, 'Locked', 'Unlocked')
+
+      expect(mockService.updateCharacteristic).toHaveBeenCalledWith(CHARACTERISTIC, 0)
+    })
+
+    it('should NOT log info message on initial discovery', async () => {
+      await device.updateCharacteristic(mockService, 'LockMechanism', CHARACTERISTIC, 0, 'LockCurrentState', 1, 'Locked', 'Unlocked')
+
+      expect(device.infoLog).not.toHaveBeenCalled()
+    })
+
+    it('should store the value in context for future comparisons', async () => {
+      await device.updateCharacteristic(mockService, 'LockMechanism', CHARACTERISTIC, 0, 'LockCurrentState', 1, 'Locked', 'Unlocked')
+
+      expect(device.accessory.context.LockMechanismLockCurrentState).toBe(0)
+    })
+  })
+
+  describe('subsequent updates with unchanged value', () => {
+    it('should NOT push to HomeKit when value has not changed', async () => {
+      // Seed context as if a previous update occurred
+      device.accessory.context.LockMechanismLockCurrentState = 1
+
+      await device.updateCharacteristic(mockService, 'LockMechanism', CHARACTERISTIC, 1, 'LockCurrentState', 1, 'Locked', 'Unlocked')
+
+      expect(mockService.updateCharacteristic).not.toHaveBeenCalled()
+    })
+
+    it('should NOT log info message when value has not changed', async () => {
+      device.accessory.context.LockMechanismLockCurrentState = 1
+
+      await device.updateCharacteristic(mockService, 'LockMechanism', CHARACTERISTIC, 1, 'LockCurrentState', 1, 'Locked', 'Unlocked')
+
+      expect(device.infoLog).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('genuine state change', () => {
+    it('should push to HomeKit when value changes', async () => {
+      device.accessory.context.LockMechanismLockCurrentState = 1
+
+      await device.updateCharacteristic(mockService, 'LockMechanism', CHARACTERISTIC, 0, 'LockCurrentState', 1, 'Locked', 'Unlocked')
+
+      expect(mockService.updateCharacteristic).toHaveBeenCalledWith(CHARACTERISTIC, 0)
+    })
+
+    it('should log "was Unlocked" when lock changes from secured to unsecured', async () => {
+      device.accessory.context.LockMechanismLockCurrentState = 1
+
+      await device.updateCharacteristic(mockService, 'LockMechanism', CHARACTERISTIC, 0, 'LockCurrentState', 1, 'Locked', 'Unlocked')
+
+      expect(device.infoLog).toHaveBeenCalledWith('was Unlocked')
+    })
+
+    it('should log "was Locked" when lock changes from unsecured to secured', async () => {
+      device.accessory.context.LockMechanismLockCurrentState = 0
+
+      await device.updateCharacteristic(mockService, 'LockMechanism', CHARACTERISTIC, 1, 'LockCurrentState', 1, 'Locked', 'Unlocked')
+
+      expect(device.infoLog).toHaveBeenCalledWith('was Locked')
+    })
+
+    it('should update context to new value', async () => {
+      device.accessory.context.LockMechanismLockCurrentState = 1
+
+      await device.updateCharacteristic(mockService, 'LockMechanism', CHARACTERISTIC, 0, 'LockCurrentState', 1, 'Locked', 'Unlocked')
+
+      expect(device.accessory.context.LockMechanismLockCurrentState).toBe(0)
+    })
+  })
+
+  describe('contact sensor state changes', () => {
+    it('should log "was Closed" when door changes to closed', async () => {
+      device.accessory.context.ContactSensorContactSensorState = 1
+
+      await device.updateCharacteristic(mockService, 'ContactSensor', 'ContactSensorState', 0, 'ContactSensorState', 1, 'Opened', 'Closed')
+
+      expect(device.infoLog).toHaveBeenCalledWith('was Closed')
+    })
+
+    it('should log "was Opened" when door changes to open', async () => {
+      device.accessory.context.ContactSensorContactSensorState = 0
+
+      await device.updateCharacteristic(mockService, 'ContactSensor', 'ContactSensorState', 1, 'ContactSensorState', 1, 'Opened', 'Closed')
+
+      expect(device.infoLog).toHaveBeenCalledWith('was Opened')
+    })
+  })
+
+  describe('updates without StatusMatch/StatusDoesNotMatch', () => {
+    it('should push to HomeKit but not log info when no status strings provided', async () => {
+      device.accessory.context.BatteryBatteryLevel = 90
+
+      await device.updateCharacteristic(mockService, 'Battery', 'BatteryLevel', 85, 'BatteryLevel')
+
+      expect(mockService.updateCharacteristic).toHaveBeenCalledWith('BatteryLevel', 85)
+      expect(device.infoLog).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('startup simulation (seeded context matches API response)', () => {
+    it('should not push to HomeKit or log when seeded context matches first API value', async () => {
+      // Simulate constructor seeding: accessory.context.LockMechanismLockCurrentState ??= SECURED
+      device.accessory.context.LockMechanismLockCurrentState = 1
+
+      // First API response returns same state (SECURED = 1)
+      await device.updateCharacteristic(mockService, 'LockMechanism', CHARACTERISTIC, 1, 'LockCurrentState', 1, 'Locked', 'Unlocked')
+
+      expect(mockService.updateCharacteristic).not.toHaveBeenCalled()
+      expect(device.infoLog).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/devices/device.ts
+++ b/src/devices/device.ts
@@ -142,15 +142,19 @@ export abstract class deviceBase {
     if (CharacteristicValue === undefined) {
       await this.debugLog(`${CharacteristicName}: ${CharacteristicValue}`)
     } else {
-      Service.updateCharacteristic(Characteristic, CharacteristicValue)
-      await this.debugLog(`updateCharacteristic ${CharacteristicName}: ${CharacteristicValue} (${CharacteristicValue === Value ? StatusMatch : StatusDoesNotMatch})`)
       const contextKey = `${ServiceName}${CharacteristicName}`
       await this.debugWarnLog(`context before: ${this.accessory.context[contextKey]}`)
       const contextBefore = this.accessory.context[contextKey]
       this.accessory.context[contextKey] = CharacteristicValue
       await this.debugWarnLog(`context after: ${this.accessory.context[contextKey]}`)
-      if ((contextBefore !== this.accessory.context[contextKey]) && StatusMatch && StatusDoesNotMatch) {
-        await this.infoLog(`was ${CharacteristicValue === Value ? StatusMatch : StatusDoesNotMatch}`)
+      await this.debugLog(`updateCharacteristic ${CharacteristicName}: ${CharacteristicValue} (${CharacteristicValue === Value ? StatusMatch : StatusDoesNotMatch})`)
+      if (contextBefore !== CharacteristicValue) {
+        // Value actually changed - push update to HomeKit
+        Service.updateCharacteristic(Characteristic, CharacteristicValue)
+        // Only log state change messages when we had a prior known value (not initial discovery)
+        if (contextBefore !== undefined && StatusMatch && StatusDoesNotMatch) {
+          await this.infoLog(`was ${CharacteristicValue === Value ? StatusMatch : StatusDoesNotMatch}`)
+        }
       }
     }
   }

--- a/src/devices/lock.test.ts
+++ b/src/devices/lock.test.ts
@@ -27,3 +27,54 @@ describe('lock pushChanges method', () => {
     expect(lockTsContent).toContain('pushChanges: ${e.message')
   })
 })
+
+describe('lock context seeding for change detection', () => {
+  const lockTsPath = join(__dirname, 'lock.ts')
+  const lockTsContent = readFileSync(lockTsPath, 'utf8')
+
+  it('should seed LockMechanism context keys for change detection', () => {
+    expect(lockTsContent).toContain('accessory.context.LockMechanismLockCurrentState ??= this.LockMechanism.LockCurrentState')
+    expect(lockTsContent).toContain('accessory.context.LockMechanismLockTargetState ??= this.LockMechanism.LockTargetState')
+  })
+
+  it('should seed ContactSensor context key for change detection', () => {
+    expect(lockTsContent).toContain('accessory.context.ContactSensorContactSensorState ??= this.ContactSensor.ContactSensorState')
+  })
+
+  it('should seed Battery context keys for change detection', () => {
+    expect(lockTsContent).toContain('accessory.context.BatteryBatteryLevel ??= this.Battery.BatteryLevel')
+    expect(lockTsContent).toContain('accessory.context.BatteryStatusLowBattery ??= this.Battery.StatusLowBattery')
+  })
+
+  it('should seed context keys after creating service objects but before initializing characteristics', () => {
+    // Verify seeding happens between object assignment and characteristic initialization
+    const lockMechanismSeed = lockTsContent.indexOf('accessory.context.LockMechanismLockCurrentState ??=')
+    const lockMechanismAssign = lockTsContent.indexOf('accessory.context.LockMechanism = this.LockMechanism as object')
+    const lockCharInit = lockTsContent.indexOf('this.LockMechanism.Service\n        .setCharacteristic(this.hap.Characteristic.Name')
+
+    expect(lockMechanismSeed).toBeGreaterThan(lockMechanismAssign)
+    expect(lockMechanismSeed).toBeLessThan(lockCharInit)
+
+    const contactSensorSeed = lockTsContent.indexOf('accessory.context.ContactSensorContactSensorState ??=')
+    const contactSensorAssign = lockTsContent.indexOf('accessory.context.ContactSensor = this.ContactSensor as object')
+    const contactCharInit = lockTsContent.indexOf('this.ContactSensor.Service\n        .setCharacteristic(this.hap.Characteristic.Name')
+
+    expect(contactSensorSeed).toBeGreaterThan(contactSensorAssign)
+    expect(contactSensorSeed).toBeLessThan(contactCharInit)
+  })
+
+  it('should use nullish coalescing assignment (??=) to preserve existing persisted values', () => {
+    // Ensure ??= is used (not = or ||=) so that persisted context values from previous runs are kept
+    const lockCurrentLine = lockTsContent.match(/accessory\.context\.LockMechanismLockCurrentState\s*\?\?=/)
+    const lockTargetLine = lockTsContent.match(/accessory\.context\.LockMechanismLockTargetState\s*\?\?=/)
+    const contactLine = lockTsContent.match(/accessory\.context\.ContactSensorContactSensorState\s*\?\?=/)
+    const batteryLevelLine = lockTsContent.match(/accessory\.context\.BatteryBatteryLevel\s*\?\?=/)
+    const batteryLowLine = lockTsContent.match(/accessory\.context\.BatteryStatusLowBattery\s*\?\?=/)
+
+    expect(lockCurrentLine).not.toBeNull()
+    expect(lockTargetLine).not.toBeNull()
+    expect(contactLine).not.toBeNull()
+    expect(batteryLevelLine).not.toBeNull()
+    expect(batteryLowLine).not.toBeNull()
+  })
+})

--- a/src/devices/lock.ts
+++ b/src/devices/lock.ts
@@ -78,6 +78,9 @@ export class LockMechanism extends deviceBase {
         LockCurrentState: accessory.context.LockCurrentState ?? this.hap.Characteristic.LockCurrentState.SECURED,
       }
       accessory.context.LockMechanism = this.LockMechanism as object
+      // Seed context keys for updateCharacteristic change detection
+      accessory.context.LockMechanismLockCurrentState ??= this.LockMechanism.LockCurrentState
+      accessory.context.LockMechanismLockTargetState ??= this.LockMechanism.LockTargetState
       // Initialize Lock Mechanism Characteristics
       this.LockMechanism.Service
         .setCharacteristic(this.hap.Characteristic.Name, this.LockMechanism.Name)
@@ -103,6 +106,8 @@ export class LockMechanism extends deviceBase {
         ContactSensorState: accessory.context.ContactSensorState ?? this.hap.Characteristic.ContactSensorState.CONTACT_NOT_DETECTED,
       }
       accessory.context.ContactSensor = this.ContactSensor as object
+      // Seed context key for updateCharacteristic change detection
+      accessory.context.ContactSensorContactSensorState ??= this.ContactSensor.ContactSensorState
       // Initialize Conact Sensor Characteristics
       this.ContactSensor.Service
         .setCharacteristic(this.hap.Characteristic.Name, this.ContactSensor.Name)
@@ -122,6 +127,9 @@ export class LockMechanism extends deviceBase {
       ChargingState: accessory.context.ChargingState ?? this.hap.Characteristic.ChargingState.NOT_CHARGING,
     }
     accessory.context.Battery = this.Battery as object
+    // Seed context keys for updateCharacteristic change detection
+    accessory.context.BatteryBatteryLevel ??= this.Battery.BatteryLevel
+    accessory.context.BatteryStatusLowBattery ??= this.Battery.StatusLowBattery
     // Initialize Battery Characteristics
     this.Battery.Service
       .setCharacteristic(this.hap.Characteristic.Name, this.Battery.Name)


### PR DESCRIPTION
**Is your enhancement related to a problem? Please describe.**

<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->

Previously, `updateCharacteristic()` pushed state to HomeKit unconditionally on every poll cycle, and logged "was Unlocked"/"was Closed" even when the plugin was just learning the current state for the first time. This triggered confusing Apple Home notifications on every Homebridge restart.

**Describe the solution you are adding**

<!-- A clear and concise description of what you want to happen. -->

**Changes Proposed in this Pull Request**

Now `updateCharacteristic()` compares against cached context before calling `Service.updateCharacteristic()`, skipping redundant updates entirely. Info log messages are further gated on having a prior known value, so initial state discovery is silent. Context keys are seeded in the `LockMechanism` constructor so the first API response has a proper baseline to compare against.

<!-- A clear and concise description of what is being changed. -->

**Describe alternatives you've considered**

<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**

<!-- Add any other context or screenshots about the feature request here. -->
