### PR TITLE
feat: add excludeLockIds option to exclude locks by ID

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -351,6 +351,16 @@
             },
             "uniqueItems": true
           },
+          "excludeLockIds": {
+            "title": "Exclude Lock IDs",
+            "type": "array",
+            "items": {
+              "title": "Lock ID",
+              "type": "string",
+              "placeholder": "TSSQ97FRDMX7TPGU3Z2HWNRDPQXJ9YSM"
+            },
+            "description": "List of Lock IDs to exclude from HomeKit. Locks with these IDs will not be discovered or registered."
+          },
           "refreshRate": {
             "title": "Refresh Rate",
             "type": "number",
@@ -488,6 +498,17 @@
           "description": "<em class='primary-text'>Specifies the interval, in seconds, between pushes to the August API.</em>"
         },
         "options.logging",
+        {
+          "key": "options.excludeLockIds",
+          "type": "array",
+          "title": "Exclude Lock IDs",
+          "expandable": true,
+          "expanded": false,
+          "orderable": false,
+          "items": [
+            "options.excludeLockIds[]"
+          ]
+        },
         "options.allowInvalidCharacters",
         "options.disableCountryCodeNormalization"
       ]

--- a/src/platform.test.ts
+++ b/src/platform.test.ts
@@ -427,6 +427,144 @@ describe('AugustPlatform', () => {
       // So Lock gets called with [device] instead of device
       expect(lockSpy).toHaveBeenCalledWith([mockDevice])
     })
+
+    it('should exclude locks matching excludeLockIds', async () => {
+      const configWithExcludes: AugustPlatformConfig = {
+        ...mockConfig,
+        options: {
+          logging: 'debug',
+          excludeLockIds: ['excluded-lock-id'],
+        },
+      }
+
+      platform = new AugustPlatform(mockLog, configWithExcludes, mockApi)
+
+      const August = await import('august-yale')
+      const mockDeviceIncluded = { lockId: 'included-lock-id', LockName: 'Included Lock' } as any
+      const mockDeviceExcluded = { lockId: 'excluded-lock-id', LockName: 'Excluded Lock' } as any
+      August.default.details = vi.fn().mockResolvedValueOnce([mockDeviceIncluded, mockDeviceExcluded])
+
+      const lockSpy = vi.spyOn(platform as any, 'Lock').mockImplementation(async () => {})
+
+      await platform.discoverDevices()
+
+      // Only the non-excluded lock should be processed
+      expect(lockSpy).toHaveBeenCalledTimes(1)
+      expect(lockSpy).toHaveBeenCalledWith(expect.objectContaining({ lockId: 'included-lock-id' }))
+    })
+
+    it('should handle case-insensitive excludeLockIds matching', async () => {
+      const configWithExcludes: AugustPlatformConfig = {
+        ...mockConfig,
+        options: {
+          logging: 'debug',
+          excludeLockIds: ['EXCLUDED-LOCK-ID'],
+        },
+      }
+
+      platform = new AugustPlatform(mockLog, configWithExcludes, mockApi)
+
+      const August = await import('august-yale')
+      const mockDeviceIncluded = { lockId: 'included-lock-id', LockName: 'Included Lock' } as any
+      const mockDeviceExcluded = { lockId: 'excluded-lock-id', LockName: 'Excluded Lock' } as any
+      August.default.details = vi.fn().mockResolvedValueOnce([mockDeviceIncluded, mockDeviceExcluded])
+
+      const lockSpy = vi.spyOn(platform as any, 'Lock').mockImplementation(async () => {})
+
+      await platform.discoverDevices()
+
+      expect(lockSpy).toHaveBeenCalledTimes(1)
+      expect(lockSpy).toHaveBeenCalledWith(expect.objectContaining({ lockId: 'included-lock-id' }))
+    })
+
+    it('should unregister cached accessories for excluded lock IDs', async () => {
+      const configWithExcludes: AugustPlatformConfig = {
+        ...mockConfig,
+        options: {
+          logging: 'debug',
+          excludeLockIds: ['excluded-lock-id'],
+        },
+      }
+
+      // Make uuid.generate return predictable UUIDs based on input
+      vi.mocked(mockApi.hap.uuid.generate).mockImplementation((input: any) => `uuid-${input}`)
+
+      platform = new AugustPlatform(mockLog, configWithExcludes, mockApi)
+
+      // Simulate a cached accessory for the excluded lock
+      const mockAccessory = {
+        UUID: 'uuid-excluded-lock-id',
+        displayName: 'Excluded Lock',
+      } as unknown as PlatformAccessory
+      platform.accessories.push(mockAccessory)
+
+      const August = await import('august-yale')
+      const mockDevice = { lockId: 'included-lock-id', LockName: 'Included Lock' } as any
+      August.default.details = vi.fn().mockResolvedValueOnce([mockDevice])
+
+      vi.spyOn(platform as any, 'Lock').mockImplementation(async () => {})
+
+      await platform.discoverDevices()
+
+      // Verify the cached accessory was unregistered
+      expect(mockApi.unregisterPlatformAccessories).toHaveBeenCalledWith(
+        'homebridge-august',
+        'August',
+        [mockAccessory],
+      )
+      // Verify the accessory was removed from the accessories array
+      expect(platform.accessories.find(a => a.UUID === 'uuid-excluded-lock-id')).toBeUndefined()
+    })
+
+    it('should not filter when excludeLockIds is empty', async () => {
+      const configWithEmptyExcludes: AugustPlatformConfig = {
+        ...mockConfig,
+        options: {
+          logging: 'debug',
+          excludeLockIds: [],
+        },
+      }
+
+      platform = new AugustPlatform(mockLog, configWithEmptyExcludes, mockApi)
+
+      const August = await import('august-yale')
+      const mockDeviceA = { lockId: 'lock-a', LockName: 'Lock A' } as any
+      const mockDeviceB = { lockId: 'lock-b', LockName: 'Lock B' } as any
+      August.default.details = vi.fn().mockResolvedValueOnce([mockDeviceA, mockDeviceB])
+
+      const lockSpy = vi.spyOn(platform as any, 'Lock').mockImplementation(async () => {})
+
+      await platform.discoverDevices()
+
+      expect(lockSpy).toHaveBeenCalledTimes(2)
+    })
+
+    it('should exclude locks when using per-device config', async () => {
+      const configWithBoth: AugustPlatformConfig = {
+        ...mockConfig,
+        options: {
+          logging: 'debug',
+          excludeLockIds: ['excluded-lock-id'],
+          devices: [
+            { lockId: 'included-lock-id', configLockName: 'My Lock', overrideHomeKitEnabled: false } as any,
+          ],
+        },
+      }
+
+      platform = new AugustPlatform(mockLog, configWithBoth, mockApi)
+
+      const August = await import('august-yale')
+      const mockDeviceIncluded = { lockId: 'included-lock-id', LockName: 'Included Lock' } as any
+      const mockDeviceExcluded = { lockId: 'excluded-lock-id', LockName: 'Excluded Lock' } as any
+      August.default.details = vi.fn().mockResolvedValueOnce([mockDeviceIncluded, mockDeviceExcluded])
+
+      const lockSpy = vi.spyOn(platform as any, 'Lock').mockImplementation(async () => {})
+
+      await platform.discoverDevices()
+
+      // Only the included lock should reach the Lock method
+      expect(lockSpy).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('validated method', () => {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -340,6 +340,32 @@ export class AugustPlatform implements DynamicPlatformPlugin {
         deviceLists = [devices]
         await this.infoLog(`Total August Locks Found: ${deviceLists.length}`)
       }
+
+      // Filter out excluded lock IDs before processing
+      const excludeLockIds = this.config.options?.excludeLockIds ?? []
+      if (excludeLockIds.length > 0) {
+        const normalizedExcludeIds = excludeLockIds.map(id => id.toUpperCase().replace(/[^A-Z0-9]+/g, ''))
+        const beforeCount = deviceLists.length
+        deviceLists = deviceLists.filter((device: any) => {
+          const normalizedLockId = (device.lockId ?? device.LockId ?? '').toUpperCase().replace(/[^A-Z0-9]+/g, '')
+          return !normalizedExcludeIds.includes(normalizedLockId)
+        })
+        const excludedCount = beforeCount - deviceLists.length
+        if (excludedCount > 0) {
+          await this.infoLog(`Excluded ${excludedCount} lock(s) via excludeLockIds config.`)
+        }
+        // Unregister cached accessories for excluded lock IDs
+        for (const excludedId of excludeLockIds) {
+          const uuid = this.api.hap.uuid.generate(excludedId)
+          const existingAccessory = this.accessories.find(accessory => accessory.UUID === uuid)
+          if (existingAccessory) {
+            this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [existingAccessory])
+            this.accessories = this.accessories.filter(accessory => accessory.UUID !== uuid)
+            await this.warnLog(`Removing excluded accessory from cache: ${existingAccessory.displayName} (${excludedId})`)
+          }
+        }
+      }
+
       if (!this.config.options?.devices) {
         await this.debugWarnLog(`August Platform Config Not Set: ${JSON.stringify(this.config.options?.devices)}`)
         const devices = deviceLists.map((v: any) => v)

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -53,6 +53,7 @@ describe('settings', () => {
   it('should define options interface', () => {
     const opts: options = {
       devices: [],
+      excludeLockIds: ['LOCK-ID-TO-EXCLUDE'],
       allowInvalidCharacters: true,
       refreshRate: 60,
       updateRate: 60,
@@ -61,6 +62,7 @@ describe('settings', () => {
     }
     expect(opts.refreshRate).toBe(60)
     expect(opts.logging).toBe('debug')
+    expect(opts.excludeLockIds).toContain('LOCK-ID-TO-EXCLUDE')
   })
 
   it('should define device interface', () => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -32,6 +32,7 @@ export interface credentials {
 
 export interface options {
   devices?: devicesConfig[]
+  excludeLockIds?: string[]
   allowInvalidCharacters?: boolean
   refreshRate?: number
   updateRate?: number


### PR DESCRIPTION
Add a new top-level `excludeLockIds` option under `options` that accepts an array of Lock IDs to exclude from discovery and registration.

## :recycle: Current situation

The existing way to hide a lock requires creating a full per-device config entry with `lockId`, `configLockName`, and `hide_device: true`. For users who simply want to ignore one or more locks (e.g. a lock already exposed natively via HomeKit, a lock shared from another account, or a lock in a detached building), this is unnecessarily verbose.

## :bulb: Proposed solution

A top-level exclude list is faster to configure and easier to understand.

## Usage

```json
{
  "platform": "August",
  "credentials": { ... },
  "options": {
    "excludeLockIds": [
      "TSSQ97FRDMX7TPGU3Z2HWNRDPQXJ9YSM",
      "ANOTHER_LOCK_ID_HERE"
    ]
  }
}
```

The setting is also available in **Homebridge Config UI X** under **Advanced Settings → Exclude Lock IDs**.
## :gear: Release Notes

- Adds a new `excludeLockIds` option under `options` that accepts an array of Lock IDs to skip during discovery. Excluded locks are never registered with Homebridge, and any previously cached accessories for those locks are automatically cleaned up.

## :heavy_plus_sign: Additional Information

- The filter runs in `discoverDevices()` immediately after the August API returns the device list and before any device processing or merging with per-device config.
- Lock ID comparison is **case-insensitive** and uses the same normalization (`toUpperCase().replace(/[^A-Z0-9]+/g, '')`) already used by `mergeBylockId` for consistency.
- If a lock was previously registered and is later added to the exclude list, its cached Homebridge accessory is unregistered so it disappears from HomeKit on the next restart.
- An empty array (or omitting the option entirely) changes nothing — all locks are discovered as before.

### Testing

1. **Basic exclusion** — verifies excluded locks are filtered out and non-excluded locks are processed
2. **Case-insensitive matching** — uppercase config vs lowercase API response
3. **Cached accessory unregistration** — verifies `unregisterPlatformAccessories` is called and the accessory is removed from the array
4. **Empty array passthrough** — verifies all devices are processed when the list is empty
5. **Combined with per-device config** — verifies exclusion works when `options.devices` is also set

### Reviewer Nudging

_Where should the reviewer start? what is a good entry point?_
