### PR TITLE
fix: prevent lock commands from being dropped and resolve startup warnings

### DIFF
--- a/src/devices/device.ts
+++ b/src/devices/device.ts
@@ -57,16 +57,19 @@ export abstract class deviceBase {
   }
 
   async getDeviceRateSettings(device: devicesConfig): Promise<void> {
-    // refreshRate
+    // Set all rate properties synchronously before any await
+    // This is critical because the constructor cannot await this method,
+    // so only code before the first await is guaranteed to run before
+    // the LockMechanism constructor uses these values.
     this.deviceRefreshRate = device.refreshRate ?? this.platform.platformRefreshRate ?? 30
+    this.deviceUpdateRate = device.updateRate ?? this.platform.platformUpdateRate ?? 5
+    this.devicePushRate = device.pushRate ?? this.platform.platformPushRate ?? 1
+
+    // Log after all assignments are complete
     const refreshRate = device.refreshRate ? 'Device Config' : this.platform.platformRefreshRate ? 'Platform Config' : 'Default'
     await this.debugLog(`Using ${refreshRate} refreshRate: ${this.deviceRefreshRate}`)
-    // updateRate
-    this.deviceUpdateRate = device.updateRate ?? this.platform.platformUpdateRate ?? 5
     const updateRate = device.updateRate ? 'Device Config' : this.platform.platformUpdateRate ? 'Platform Config' : 'Default'
     await this.debugLog(`Using ${updateRate} updateRate: ${this.deviceUpdateRate}`)
-    // pushRate
-    this.devicePushRate = device.pushRate ?? this.platform.platformPushRate ?? 1
     const pushRate = device.pushRate ? 'Device Config' : this.platform.platformPushRate ? 'Platform Config' : 'Default'
     await this.debugLog(`Using ${pushRate} pushRate: ${this.devicePushRate}`)
   }

--- a/src/devices/lock.test.ts
+++ b/src/devices/lock.test.ts
@@ -128,3 +128,50 @@ describe('parseStatus uses lockStatus not lockEvent', () => {
     expect(parseStatusBody).toContain('this.lockStatus.state.unlocked')
   })
 })
+
+describe('lock commands are not dropped during updates', () => {
+  const lockTsPath = join(__dirname, 'lock.ts')
+  const lockTsContent = readFileSync(lockTsPath, 'utf8')
+
+  const parseStatusMatch = lockTsContent.match(/async parseStatus\(\)[\s\S]*?(?=\n {2}async parseEventStatus)/)
+  const parseEventStatusMatch = lockTsContent.match(/async parseEventStatus\(\)[\s\S]*?(?=\n {2}\/\*\*|\n {2}async refreshStatus)/)
+  const parseStatusBody = parseStatusMatch?.[0] ?? ''
+  const parseEventStatusBody = parseEventStatusMatch?.[0] ?? ''
+
+  it('should use filter (not skipWhile) on the refresh interval', () => {
+    // skipWhile only suppresses at the start of the stream and then permanently
+    // stops filtering. filter evaluates on every emission.
+    expect(lockTsContent).toContain('filter(() => !this.lockUpdateInProgress)')
+    expect(lockTsContent).not.toContain('skipWhile')
+  })
+
+  it('should import filter from rxjs/operators', () => {
+    expect(lockTsContent).toMatch(/import\s*\{[^}]*filter[^}]*\}\s*from\s*'rxjs\/operators'/)
+  })
+
+  it('should guard LockTargetState sync in parseStatus with lockUpdateInProgress', () => {
+    // parseStatus must NOT unconditionally overwrite TargetState, or it will
+    // erase the user's lock/unlock intent before pushChanges can act on it
+    expect(parseStatusBody).toContain('if (!this.lockUpdateInProgress)')
+    expect(parseStatusBody).toContain('this.LockMechanism.LockTargetState = this.LockMechanism.LockCurrentState')
+  })
+
+  it('should guard LockTargetState sync in parseEventStatus with lockUpdateInProgress', () => {
+    // PubNub events arrive continuously and must not reset TargetState during updates
+    expect(parseEventStatusBody).toContain('if (!this.lockUpdateInProgress)')
+    expect(parseEventStatusBody).toContain('this.LockMechanism.LockTargetState = this.LockMechanism.LockCurrentState')
+  })
+
+  it('should always update LockCurrentState regardless of lockUpdateInProgress', () => {
+    // LockCurrentState should reflect the physical lock state at all times.
+    // The lockUpdateInProgress guard must only wrap TargetState, not CurrentState.
+    // Verify that the CurrentState assignment is NOT inside the guard.
+    const parseStatusCurrentAssign = parseStatusBody.indexOf('this.LockMechanism.LockCurrentState = this.lockStatus.state.locked')
+    const parseStatusGuard = parseStatusBody.indexOf('if (!this.lockUpdateInProgress)')
+    expect(parseStatusCurrentAssign).toBeLessThan(parseStatusGuard)
+
+    const parseEventCurrentAssign = parseEventStatusBody.indexOf('this.LockMechanism.LockCurrentState = this.lockEvent.state.locked')
+    const parseEventGuard = parseEventStatusBody.indexOf('if (!this.lockUpdateInProgress)')
+    expect(parseEventCurrentAssign).toBeLessThan(parseEventGuard)
+  })
+})

--- a/src/devices/lock.ts
+++ b/src/devices/lock.ts
@@ -9,7 +9,7 @@ import type { device, devicesConfig, lockDetails, lockEvent, lockStatus } from '
  */
 import August from 'august-yale'
 import { interval, Subject } from 'rxjs'
-import { debounceTime, skipWhile, tap } from 'rxjs/operators'
+import { debounceTime, filter, tap } from 'rxjs/operators'
 
 import { deviceBase } from './device.js'
 
@@ -153,7 +153,7 @@ export class LockMechanism extends deviceBase {
 
     // Start an update interval
     interval(this.deviceRefreshRate * 1000)
-      .pipe(skipWhile(() => this.lockUpdateInProgress))
+      .pipe(filter(() => !this.lockUpdateInProgress))
       .subscribe(async () => {
         await this.refreshStatus()
       })
@@ -200,7 +200,9 @@ export class LockMechanism extends deviceBase {
             : this.lockStatus.state.unlocked
               ? this.hap.Characteristic.LockCurrentState.UNSECURED
               : retryCount > 1 ? this.hap.Characteristic.LockCurrentState.JAMMED : this.hap.Characteristic.LockCurrentState.UNKNOWN
-          this.LockMechanism.LockTargetState = this.LockMechanism.LockCurrentState
+          if (!this.lockUpdateInProgress) {
+            this.LockMechanism.LockTargetState = this.LockMechanism.LockCurrentState
+          }
 
           if (this.LockMechanism.LockCurrentState === this.hap.Characteristic.LockCurrentState.UNKNOWN) {
             await this.warnLog(`LockCurrentState: ${this.LockMechanism.LockCurrentState}, (UNKNOWN) parseStatus`
@@ -272,7 +274,9 @@ export class LockMechanism extends deviceBase {
             : this.lockEvent.state.unlocked
               ? this.hap.Characteristic.LockCurrentState.UNSECURED
               : retryCount > 1 ? this.hap.Characteristic.LockCurrentState.JAMMED : this.hap.Characteristic.LockCurrentState.UNKNOWN
-          this.LockMechanism.LockTargetState = this.LockMechanism.LockCurrentState
+          if (!this.lockUpdateInProgress) {
+            this.LockMechanism.LockTargetState = this.LockMechanism.LockCurrentState
+          }
 
           if (this.LockMechanism.LockCurrentState === this.hap.Characteristic.LockCurrentState.UNKNOWN) {
             await this.warnLog(`LockCurrentState: ${this.LockMechanism.LockCurrentState}, (UNKNOWN) parseEventStatus`

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -201,6 +201,8 @@ export class AugustPlatform implements DynamicPlatformPlugin {
   async augustCredentials() {
     if (!this.config.credentials) {
       throw new Error('Missing Credentials')
+    } else if (this.augustConfig) {
+      await this.debugLog('August API instance already initialized, skipping')
     } else {
       // Create normalized credentials for August API compatibility
       const normalizedCredentials = await this.normalizeCredentialsForApi(this.config.credentials)
@@ -295,12 +297,13 @@ export class AugustPlatform implements DynamicPlatformPlugin {
       if (this.augustConfig) {
         await this.debugLog('Refreshing August session due to timeout error')
         this.augustConfig.end() // Clear the current token to force re-authentication
+        this.augustConfig = undefined as any // Allow augustCredentials() to create a fresh instance
+        await this.augustCredentials()
         await this.debugLog('August session refreshed successfully')
       }
     } catch (e: any) {
       await this.errorLog(`Failed to refresh August session: ${e.message ?? e}`)
     }
-
   }
 
   async pluginConfig() {
@@ -329,6 +332,11 @@ export class AugustPlatform implements DynamicPlatformPlugin {
   async discoverDevices() {
     // August Locks
     try {
+      // Ensure the August API instance is initialized before processing
+      // devices. augustCredentials() is idempotent — safe to call if
+      // already initialized (e.g. from the validated() path).
+      await this.augustCredentials()
+
       const normalizedCredentials = await this.normalizeCredentialsForApi(this.config.credentials!)
       const devices = await August.details(normalizedCredentials, '')
       


### PR DESCRIPTION
## :recycle: Current situation

### 1. Lock commands silently dropped

Tapping lock/unlock in the Home app does nothing. The lock never physically moves. No error is logged.

Both `parseStatus()` and `parseEventStatus()` unconditionally overwrite `LockTargetState` to match `LockCurrentState` every time they run:

```typescript
this.LockMechanism.LockTargetState = this.LockMechanism.LockCurrentState
```

Before v3.0.7, `parseStatus()` crashed on every call (the `lockEvent` bug), so this line never executed. Now that it works correctly, it runs on every refresh poll and every PubNub event — erasing the user's lock/unlock intent before `pushChanges()` can act on it.

Additionally, `skipWhile` on the refresh interval only suppresses emissions at the start of the observable stream. Once it sees `lockUpdateInProgress === false` after the first refresh cycle on startup, it permanently passes all subsequent emissions regardless of the flag.

The sequence when a user taps Unlock:

1. `setLockTargetState(UNSECURED)` — sets `LockTargetState = 0`
2. `doLockUpdate.next()` — `debounceTime` waits 1 second
3. During that window, a refresh poll or PubNub event arrives
4. `parseStatus`/`parseEventStatus` resets `LockTargetState` back to `SECURED`
5. `pushChanges()` sees `TargetState === CurrentState` → "No changes" → no API call

### 2. TimeoutNaN warning and wrong debounce timing

Node emits on every startup:

```
TimeoutNaNWarning: NaN is not a number. Timeout duration was set to 1.
```

`getDeviceRateSettings()` in `device.ts` is `async` but called without `await` in the constructor (constructors can't `await`). An async function runs synchronously only until its first `await`:

```
this.deviceRefreshRate = 30       ← runs (before first await)
await this.debugLog(...)          ← SUSPENDS — returns to constructor
this.deviceUpdateRate = 5         ← deferred (runs later)
this.devicePushRate = 1           ← deferred (runs later)
```

The `LockMechanism` constructor then uses `this.devicePushRate` which is still `undefined`. `undefined * 1000 = NaN` → Node clamps to 1ms and emits the warning. This also means the debounce timer on lock commands runs at 1ms instead of the intended 1 second.

### 3. First lock "No details" and August API lifecycle

The first lock always logs on startup:

```
[August] Lock: Laundry Door (refreshStatus) lockDetails: No details
```

`discoverDevices()` uses the static `August.details()` to fetch the lock list but never calls `augustCredentials()` to create the API instance (`this.augustConfig`). The `validated()` path creates it, but the normal startup path (`isValidated === true`) skips `validated()` entirely and calls `discoverDevices()` directly.

Each `LockMechanism` constructor fires `refreshStatus()` as fire-and-forget. The first lock's `refreshStatus()` checks `this.platform.augustConfig` — it's `undefined` because nobody has initialized it yet. It falls to the else branch and logs "No details". By the second lock, the first lock's `subscribeAugust()` may have completed `augustCredentials()`, masking the issue for subsequent locks.

Two additional problems with `augustCredentials()`:

- It blindly creates a new `August()` instance on every call. With N locks, each lock's `subscribeAugust()` creates a new instance and discards the previous one without cleanup — each potentially holding open PubNub connections and session state.
- `refreshAugustSession()` calls `augustConfig.end()` to clear the session but never nulls the reference or creates a replacement. Subsequent API calls use the dead (ended) instance.

## :bulb: Proposed solution

**Lock command fix (`lock.ts`):**

- `skipWhile` → `filter` on the refresh interval. `filter` evaluates on every emission, correctly dropping polls when `lockUpdateInProgress` is true.
- Guard `LockTargetState` sync in `parseStatus()` with `if (!this.lockUpdateInProgress)`. Prevents refresh responses from overwriting the user's intent.
- Guard `LockTargetState` sync in `parseEventStatus()` with the same check. Prevents PubNub events from resetting `LockTargetState` during the debounce window.
- `LockCurrentState` is always updated regardless — HomeKit always reflects the physical lock state. When `lockUpdateInProgress` is false (steady state), the sync runs normally so external changes (physical keypad, August app) are reflected.

**Rate initialization fix (`device.ts`):**

- All three rate property assignments (`deviceRefreshRate`, `deviceUpdateRate`, `devicePushRate`) moved before the first `await` so they execute synchronously during construction.

**August API lifecycle fix (`platform.ts`):**

- `augustCredentials()` made idempotent — returns immediately if `this.augustConfig` already exists. Callers don't need guards; they just call the method and it does the right thing.
- `discoverDevices()` now calls `augustCredentials()` at the top so the API instance exists before any lock is processed.
- `refreshAugustSession()` properly cycles the instance: `end()` the old one, null the reference, call `augustCredentials()` to create a fresh one.

## :gear: Release Notes

- Locks respond to lock/unlock commands from the Home app immediately.
- `TimeoutNaNWarning` and `(refreshStatus) lockDetails: No details` warnings are gone.
- Lock command debounce now runs at the correct configured rate instead of 1ms.
- August API session refresh now properly recreates the connection instead of leaving a dead instance.

## :heavy_plus_sign: Additional Information

### Testing

- 5 new regression tests for the lock command fix covering: `filter` vs `skipWhile`, `filter` import, `lockUpdateInProgress` guard in `parseStatus`, guard in `parseEventStatus`, and `LockCurrentState` always updating outside the guard.
- All 5 tests fail against unfixed code, confirming they catch the bug.