### PR TITLE
fix: prevent 502 errors from cascading across all locks

### DIFF
--- a/src/devices/lock.test.ts
+++ b/src/devices/lock.test.ts
@@ -214,7 +214,7 @@ describe('session refresh prevents 502 cascade', () => {
   it('should re-subscribe all locks after cycling the instance', () => {
     // Without re-subscription, end() kills all PubNub subscriptions
     // and they are never re-established — causing hours of 502s
-    expect(executeBody).toContain('for (const resubscribe of this.resubscribeCallbacks)')
+    expect(executeBody).toContain('for (const resubscribe of this.resubscribeCallbacks.values())')
   })
 
   it('should end the old instance before creating a new one', () => {
@@ -230,11 +230,20 @@ describe('session refresh prevents 502 cascade', () => {
     expect(resubscribeLoop).toBeGreaterThan(credentialsCall)
   })
 
-  it('should register a resubscribe callback in the lock constructor', () => {
-    expect(lockTsContent).toContain('this.platform.registerResubscribeCallback(() => this.subscribeAugust())')
+  it('should register a resubscribe callback keyed by lockId in the lock constructor', () => {
+    expect(lockTsContent).toMatch(/this\.platform\.registerResubscribeCallback\(this\.device\.lockId,/)
   })
 
-  it('should expose registerResubscribeCallback as a public method', () => {
-    expect(platformTsContent).toMatch(/public registerResubscribeCallback\(/)
+  it('should use a Map for resubscribe callbacks to allow cleanup by lockId', () => {
+    expect(platformTsContent).toContain('new Map<string, () => Promise<void>>()')
+  })
+
+  it('should expose registerResubscribeCallback and unregisterResubscribeCallback', () => {
+    expect(platformTsContent).toMatch(/public registerResubscribeCallback\(lockId: string,/)
+    expect(platformTsContent).toMatch(/public unregisterResubscribeCallback\(lockId: string\)/)
+  })
+
+  it('should clean up resubscribe callback when unregistering accessories', () => {
+    expect(platformTsContent).toMatch(/unregisterResubscribeCallback\(device\.lockId\)/)
   })
 })

--- a/src/devices/lock.test.ts
+++ b/src/devices/lock.test.ts
@@ -175,3 +175,66 @@ describe('lock commands are not dropped during updates', () => {
     expect(parseEventCurrentAssign).toBeLessThan(parseEventGuard)
   })
 })
+
+describe('session refresh prevents 502 cascade', () => {
+  const lockTsPath = join(__dirname, 'lock.ts')
+  const lockTsContent = readFileSync(lockTsPath, 'utf8')
+  const platformTsPath = join(__dirname, '..', 'platform.ts')
+  const platformTsContent = readFileSync(platformTsPath, 'utf8')
+
+  // Extract refreshAugustSession and executeSessionRefresh
+  const refreshMatch = platformTsContent.match(/async refreshAugustSession\(\)[\s\S]*?(?=\n {2}private async executeSessionRefresh)/)
+  const executeMatch = platformTsContent.match(/private async executeSessionRefresh\(\)[\s\S]*?(?=\n {2}async pluginConfig)/)
+  const refreshBody = refreshMatch?.[0] ?? ''
+  const executeBody = executeMatch?.[0] ?? ''
+
+  it('should have extractable refreshAugustSession and executeSessionRefresh methods', () => {
+    expect(refreshBody.length).toBeGreaterThan(0)
+    expect(executeBody.length).toBeGreaterThan(0)
+  })
+
+  it('should use promise coalescing, not a boolean flag', () => {
+    // Promise coalescing: concurrent callers share the same promise.
+    // Boolean flag causes "skip" — callers retry with a dead instance.
+    expect(refreshBody).toContain('this.sessionRefreshPromise')
+    expect(platformTsContent).not.toContain('sessionRefreshInProgress')
+  })
+
+  it('should return the existing promise when a refresh is already in progress', () => {
+    // This is the coalescing: callers await the in-flight refresh
+    // instead of starting their own or skipping entirely
+    expect(refreshBody).toContain('return this.sessionRefreshPromise')
+  })
+
+  it('should clear the promise after refresh completes', () => {
+    // Ensures the next 502 triggers a fresh refresh
+    expect(refreshBody).toContain('this.sessionRefreshPromise = undefined')
+  })
+
+  it('should re-subscribe all locks after cycling the instance', () => {
+    // Without re-subscription, end() kills all PubNub subscriptions
+    // and they are never re-established — causing hours of 502s
+    expect(executeBody).toContain('for (const resubscribe of this.resubscribeCallbacks)')
+  })
+
+  it('should end the old instance before creating a new one', () => {
+    const endCall = executeBody.indexOf('.end()')
+    const nullAssign = executeBody.indexOf('this.augustConfig = undefined')
+    const credentialsCall = executeBody.indexOf('this.augustCredentials()')
+    const resubscribeLoop = executeBody.indexOf('for (const resubscribe')
+
+    // Verify the order: end → null → create → resubscribe
+    expect(endCall).toBeGreaterThan(-1)
+    expect(nullAssign).toBeGreaterThan(endCall)
+    expect(credentialsCall).toBeGreaterThan(nullAssign)
+    expect(resubscribeLoop).toBeGreaterThan(credentialsCall)
+  })
+
+  it('should register a resubscribe callback in the lock constructor', () => {
+    expect(lockTsContent).toContain('this.platform.registerResubscribeCallback(() => this.subscribeAugust())')
+  })
+
+  it('should expose registerResubscribeCallback as a public method', () => {
+    expect(platformTsContent).toMatch(/public registerResubscribeCallback\(/)
+  })
+})

--- a/src/devices/lock.ts
+++ b/src/devices/lock.ts
@@ -148,8 +148,9 @@ export class LockMechanism extends deviceBase {
     // Initial Device Refresh
     this.refreshStatus()
 
-    // Subscribe to august changes
+    // Subscribe to august changes and register for re-subscription after session refresh
     this.subscribeAugust()
+    this.platform.registerResubscribeCallback(() => this.subscribeAugust())
 
     // Start an update interval
     interval(this.deviceRefreshRate * 1000)

--- a/src/devices/lock.ts
+++ b/src/devices/lock.ts
@@ -150,7 +150,7 @@ export class LockMechanism extends deviceBase {
 
     // Subscribe to august changes and register for re-subscription after session refresh
     this.subscribeAugust()
-    this.platform.registerResubscribeCallback(() => this.subscribeAugust())
+    this.platform.registerResubscribeCallback(this.device.lockId, () => this.subscribeAugust())
 
     // Start an update interval
     interval(this.deviceRefreshRate * 1000)

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -37,6 +37,11 @@ export class AugustPlatform implements DynamicPlatformPlugin {
   // August API
   augustConfig!: August
 
+  // Session refresh: promise coalescing ensures concurrent 502s from
+  // multiple locks share a single refresh instead of cascading.
+  private sessionRefreshPromise?: Promise<void>
+  private readonly resubscribeCallbacks: (() => Promise<void>)[] = []
+
   // Cached normalized credentials for performance
   private normalizedCredentialsCache?: credentials
 
@@ -290,17 +295,49 @@ export class AugustPlatform implements DynamicPlatformPlugin {
   }
 
   /**
-   * Refresh August session by clearing current token
+   * Register a callback to re-establish a lock's PubNub subscription
+   * after a session refresh. Called by each LockMechanism during construction.
+   */
+  public registerResubscribeCallback(callback: () => Promise<void>): void {
+    this.resubscribeCallbacks.push(callback)
+  }
+
+  /**
+   * Refresh the August session and re-subscribe all locks.
+   *
+   * Uses promise coalescing: if multiple locks hit 502 simultaneously,
+   * they all await the same refresh promise instead of each triggering
+   * their own. This prevents the cascade where Lock A's refresh destroys
+   * Lock B's fresh instance.
    */
   async refreshAugustSession(): Promise<void> {
+    if (this.sessionRefreshPromise) {
+      return this.sessionRefreshPromise
+    }
+    this.sessionRefreshPromise = this.executeSessionRefresh()
+    try {
+      await this.sessionRefreshPromise
+    } finally {
+      this.sessionRefreshPromise = undefined
+    }
+  }
+
+  private async executeSessionRefresh(): Promise<void> {
     try {
       if (this.augustConfig) {
-        await this.debugLog('Refreshing August session due to timeout error')
-        this.augustConfig.end() // Clear the current token to force re-authentication
-        this.augustConfig = undefined as any // Allow augustCredentials() to create a fresh instance
-        await this.augustCredentials()
-        await this.debugLog('August session refreshed successfully')
+        await this.warnLog('Refreshing August session due to timeout error')
+        this.augustConfig.end()
+        this.augustConfig = undefined as any
       }
+      await this.augustCredentials()
+      for (const resubscribe of this.resubscribeCallbacks) {
+        try {
+          await resubscribe()
+        } catch (e: any) {
+          await this.errorLog(`Failed to re-subscribe lock after session refresh: ${e.message ?? e}`)
+        }
+      }
+      await this.warnLog('August session refreshed and all locks re-subscribed')
     } catch (e: any) {
       await this.errorLog(`Failed to refresh August session: ${e.message ?? e}`)
     }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -40,7 +40,7 @@ export class AugustPlatform implements DynamicPlatformPlugin {
   // Session refresh: promise coalescing ensures concurrent 502s from
   // multiple locks share a single refresh instead of cascading.
   private sessionRefreshPromise?: Promise<void>
-  private readonly resubscribeCallbacks: (() => Promise<void>)[] = []
+  private readonly resubscribeCallbacks = new Map<string, () => Promise<void>>()
 
   // Cached normalized credentials for performance
   private normalizedCredentialsCache?: credentials
@@ -298,8 +298,12 @@ export class AugustPlatform implements DynamicPlatformPlugin {
    * Register a callback to re-establish a lock's PubNub subscription
    * after a session refresh. Called by each LockMechanism during construction.
    */
-  public registerResubscribeCallback(callback: () => Promise<void>): void {
-    this.resubscribeCallbacks.push(callback)
+  public registerResubscribeCallback(lockId: string, callback: () => Promise<void>): void {
+    this.resubscribeCallbacks.set(lockId, callback)
+  }
+
+  public unregisterResubscribeCallback(lockId: string): void {
+    this.resubscribeCallbacks.delete(lockId)
   }
 
   /**
@@ -330,7 +334,7 @@ export class AugustPlatform implements DynamicPlatformPlugin {
         this.augustConfig = undefined as any
       }
       await this.augustCredentials()
-      for (const resubscribe of this.resubscribeCallbacks) {
+      for (const resubscribe of this.resubscribeCallbacks.values()) {
         try {
           await resubscribe()
         } catch (e: any) {
@@ -405,6 +409,7 @@ export class AugustPlatform implements DynamicPlatformPlugin {
           const existingAccessory = this.accessories.find(accessory => accessory.UUID === uuid)
           if (existingAccessory) {
             this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [existingAccessory])
+            this.unregisterResubscribeCallback(excludedId)
             this.accessories = this.accessories.filter(accessory => accessory.UUID !== uuid)
             await this.warnLog(`Removing excluded accessory from cache: ${existingAccessory.displayName} (${excludedId})`)
           }
@@ -574,6 +579,7 @@ export class AugustPlatform implements DynamicPlatformPlugin {
   public async unregisterPlatformAccessories(existingAccessory: PlatformAccessory, device: device & devicesConfig) {
     // remove platform accessories when no longer present
     this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [existingAccessory])
+    this.unregisterResubscribeCallback(device.lockId)
     await this.warnLog(`Removing existing accessory from cache: ${device.LockName}`)
   }
 


### PR DESCRIPTION
## :recycle: Current situation

When any lock gets a 502 from August's API, `refreshAugustSession()` calls `end()` on the August instance. The problem is that `end()` kills PubNub subscriptions for *all* locks, not just the one that hit the error. A new instance gets created, but none of the locks re-subscribe to it.

So then the next lock tries to poll, hits a 502 because its subscription is dead, calls `refreshAugustSession()` again, which nukes the instance that the first lock just created. Every lock does this in turn and it never recovers:

```
[August] Lock: Laundry Door (refreshStatus) lockDetails: POST failed with: 502
[August] Lock: Laundry Door (refreshStatus retry) failed: POST failed with: 502
[August] Lock: Front Door (refreshStatus) lockDetails: POST failed with: 502
[August] Lock: Front Door (refreshStatus retry) failed: POST failed with: 502
... (goes on for hours until you manually restart Homebridge)
```

The underlying issue is that session refresh has global side effects but gets triggered independently by each lock's error handler with no coordination.

## :bulb: Proposed solution

**Promise coalescing for session refresh.** Instead of each lock firing its own refresh, concurrent callers share the same one:

- First lock to hit 502 creates a refresh promise via `executeSessionRefresh()`
- Any other locks that hit 502 while it's running just `return` and await that same promise
- `executeSessionRefresh()` tears down the old instance (if it exists), then unconditionally calls `augustCredentials()` to create a new one - the teardown is guarded but the rebuild always runs, so you're guaranteed a working instance regardless of prior state
- `finally` clears the promise so the next 502 down the road triggers a fresh refresh

**Re-subscribe all locks after cycling.** Each `LockMechanism` registers a callback during construction via `platform.registerResubscribeCallback(lockId, callback)`. After the session cycles, `executeSessionRefresh()` walks all the callbacks and re-establishes every lock's PubNub subscription on the new instance.

**Map keyed by lock ID instead of array.** Registering the same lock twice just overwrites. Removing a lock calls `unregisterResubscribeCallback(lockId)` to clean up - no stale closures holding references to dead `LockMechanism` instances. Cleanup hooks into both removal paths: `unregisterPlatformAccessories()` and the `excludeLockIds` filter.

Net result:
- A single 502 triggers exactly one refresh, shared across all locks
- All PubNub subscriptions get restored on the new instance
- No cascade, no hours of errors, no manual restart needed
- If August's servers are genuinely down, locks just retry on their own poll schedule without stomping on each other

## :gear: Release Notes

502 errors from August's API no longer cascade across all locks for hours. When a session error occurs, the plugin refreshes the connection once and automatically re-subscribes all locks. Previously a single 502 could trigger a chain reaction where each lock destroyed the session the previous lock just created, requiring a manual Homebridge restart to recover.

## :heavy_plus_sign: Additional Information

### Testing

10 new regression tests covering promise coalescing, re-subscribe ordering, Map-based registry, lock ID keyed registration, unregister cleanup, etc. All fail against unfixed code.