### PR TITLE
fix: add cooldown to session refresh to prevent wasted refreshes

### DIFF
--- a/src/devices/lock.test.ts
+++ b/src/devices/lock.test.ts
@@ -288,3 +288,36 @@ describe('session refresh and PubNub subscription lifecycle', () => {
     expect(body).toContain('this.lockMechanisms.delete')
   })
 })
+
+describe('session refresh cooldown', () => {
+  const platformTsPath = join(__dirname, '..', 'platform.ts')
+  const platformTsContent = readFileSync(platformTsPath, 'utf8')
+  const refreshMatch = platformTsContent.match(/async refreshAugustSession\(\)[\s\S]*?(?=\n {2}private async executeSessionRefresh)/)
+  const refreshBody = refreshMatch?.[0] ?? ''
+
+  it('should track the time of the last refresh attempt', () => {
+    expect(platformTsContent).toMatch(/lastSessionRefresh\s*=\s*0/)
+  })
+
+  it('should define a cooldown constant', () => {
+    expect(platformTsContent).toMatch(/SESSION_REFRESH_COOLDOWN_MS/)
+  })
+
+  it('should skip refresh when within the cooldown window', () => {
+    expect(refreshBody).toContain('sinceLastRefresh')
+    expect(refreshBody).toMatch(/sinceLastRefresh\s*<\s*AugustPlatform\.SESSION_REFRESH_COOLDOWN_MS/)
+  })
+
+  it('should update lastSessionRefresh after a refresh completes', () => {
+    expect(refreshBody).toContain('this.lastSessionRefresh = Date.now()')
+  })
+
+  it('should check cooldown after coalescing check', () => {
+    // Promise coalescing should still take priority over the cooldown.
+    // If a refresh is in flight, callers await it regardless of cooldown.
+    const coalescingCheck = refreshBody.indexOf('this.sessionRefreshPromise')
+    const cooldownCheck = refreshBody.indexOf('sinceLastRefresh')
+    expect(coalescingCheck).toBeGreaterThan(-1)
+    expect(cooldownCheck).toBeGreaterThan(coalescingCheck)
+  })
+})

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -40,6 +40,11 @@ export class AugustPlatform implements DynamicPlatformPlugin {
   // Session refresh: promise coalescing ensures concurrent 502s from
   // multiple locks share a single refresh instead of cascading.
   private sessionRefreshPromise?: Promise<void>
+  // Cooldown prevents wasted sequential refreshes during prolonged
+  // network outages, where every poll cycle would otherwise trigger
+  // a new POST /session call (and risk rate limiting).
+  private lastSessionRefresh = 0
+  private static readonly SESSION_REFRESH_COOLDOWN_MS = 5 * 60 * 1000 // 5 minutes
 
   // Track LockMechanism instances by lockId so they can be properly torn
   // down when the accessory is unregistered (releases PubNub subscriptions).
@@ -305,6 +310,12 @@ export class AugustPlatform implements DynamicPlatformPlugin {
    * their own. This prevents cascading refreshes where each lock destroys
    * the instance the previous lock just created.
    *
+   * Also enforces a cooldown period: refreshes within SESSION_REFRESH_COOLDOWN_MS
+   * of the last attempt are skipped. This prevents wasted sequential refreshes
+   * during prolonged network outages — without this, every poll cycle (default
+   * 30s) would trigger a new POST /session call to August, risking rate limiting
+   * and spamming logs.
+   *
    * PubNub subscriptions are independent of the HTTP session (August.subscribe
    * uses its own internal August instance), so they are NOT torn down or
    * rebuilt during a session refresh. Only the HTTP client (augustConfig)
@@ -314,9 +325,16 @@ export class AugustPlatform implements DynamicPlatformPlugin {
     if (this.sessionRefreshPromise) {
       return this.sessionRefreshPromise
     }
+    const sinceLastRefresh = Date.now() - this.lastSessionRefresh
+    if (sinceLastRefresh < AugustPlatform.SESSION_REFRESH_COOLDOWN_MS) {
+      const remainingSeconds = Math.ceil((AugustPlatform.SESSION_REFRESH_COOLDOWN_MS - sinceLastRefresh) / 1000)
+      await this.debugLog(`Session refresh skipped: cooldown active (${remainingSeconds}s remaining)`)
+      return
+    }
     this.sessionRefreshPromise = this.executeSessionRefresh()
     try {
       await this.sessionRefreshPromise
+      this.lastSessionRefresh = Date.now()
     } finally {
       this.sessionRefreshPromise = undefined
     }


### PR DESCRIPTION
# fix: add cooldown to session refresh to prevent wasted refreshes

## :recycle: Current situation

When August's API is unreachable (network issues, DNS, etc.), every lock's poll fails and triggers `refreshAugustSession()`. Promise coalescing handles the concurrent case, but during a sustained outage each lock still fires a refresh sequentially every poll cycle - one `POST /session` per lock per 30 seconds, indefinitely. This risks Cloudflare rate-limiting and spams the logs:

```
[08:37:24] Refreshing August session due to timeout error
[08:37:24] Lock: Side Door (refreshStatus retry) failed: read ETIMEDOUT
[08:37:25] Refreshing August session due to timeout error
[08:37:25] Lock: Garage Door (refreshStatus retry) failed: read ETIMEDOUT
[08:37:25] Refreshing August session due to timeout error
[08:37:25] Lock: Front Door (refreshStatus retry) failed: read ETIMEDOUT
```

Three refreshes in one second, none of which help.

## :bulb: Proposed solution

5 minute cooldown on `refreshAugustSession()`. First failure triggers a refresh; subsequent calls within 5 minutes skip silently. Cooldown check runs after the existing coalescing check so in-flight refreshes still get awaited.

## :gear: Release Notes

Session refreshes during prolonged network outages are now rate-limited to once every 5 minutes, preventing wasted API calls and log spam.

## :heavy_plus_sign: Additional Information

### Testing

- 5 new tests

### Reviewer Nudging
