### PR TITLE
fix: broaden engines for v1.x and detect august-yale TimeoutError

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@homebridge-plugins/homebridge-august",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "funding": [
         {
           "type": "Paypal",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "main": "dist/index.js",
   "engines": {
-    "homebridge": "^2.0.0-beta.89",
+    "homebridge": "^1.8.0 || ^2.0.0-beta.0",
     "node": "^22 || ^24"
   },
   "scripts": {

--- a/src/devices/device.test.ts
+++ b/src/devices/device.test.ts
@@ -49,9 +49,10 @@ class MockDevice {
    * Check if error is a network timeout or session expiration that requires session refresh
    * Handles 502 Bad Gateway, 401 Unauthorized, 503 Service Unavailable, and network timeouts
    */
-  isTimeoutError(error: { message: string, statusCode?: number }): boolean {
-    // Check for network timeout errors
-    if (error.message && error.message.includes('ETIMEDOUT')) {
+  isTimeoutError(error: { message: string, name?: string, statusCode?: number }): boolean {
+    // Check for august-yale TimeoutError by name (stable contract — works regardless
+    // of message format changes) and Node.js network timeouts by message
+    if (error.name === 'TimeoutError' || error.message?.includes('ETIMEDOUT')) {
       return true
     }
 
@@ -113,6 +114,16 @@ describe('statusCode error handling', () => {
   })
 
   describe('isTimeoutError method', () => {
+    it('should detect august-yale TimeoutError by error.name', () => {
+      const error = { message: 'Request timed out after 30000ms', name: 'TimeoutError' }
+      expect(mockDevice.isTimeoutError(error)).toBe(true)
+    })
+
+    it('should detect august-yale TimeoutError regardless of message content', () => {
+      const error = { message: 'anything', name: 'TimeoutError' }
+      expect(mockDevice.isTimeoutError(error)).toBe(true)
+    })
+
     it('should detect ETIMEDOUT network errors', () => {
       const error = { message: 'ETIMEDOUT connection timed out' }
       expect(mockDevice.isTimeoutError(error)).toBe(true)
@@ -170,6 +181,11 @@ describe('statusCode error handling', () => {
 
     it('should return false for empty message', () => {
       const error = { message: '' }
+      expect(mockDevice.isTimeoutError(error)).toBe(false)
+    })
+
+    it('should return false for errors with non-timeout name', () => {
+      const error = { message: 'something failed', name: 'Error' }
       expect(mockDevice.isTimeoutError(error)).toBe(false)
     })
 

--- a/src/devices/device.ts
+++ b/src/devices/device.ts
@@ -192,9 +192,10 @@ export abstract class deviceBase {
    * Check if error is a network timeout or session expiration that requires session refresh
    * Handles 502 Bad Gateway, 401 Unauthorized, 503 Service Unavailable, and network timeouts
    */
-  isTimeoutError(error: { message: string, statusCode?: number }): boolean {
-    // Check for network timeout errors
-    if (error.message && error.message.includes('ETIMEDOUT')) {
+  isTimeoutError(error: { message: string, name?: string, statusCode?: number }): boolean {
+    // Check for august-yale TimeoutError by name (stable contract — works regardless
+    // of message format changes) and Node.js network timeouts by message
+    if (error.name === 'TimeoutError' || error.message?.includes('ETIMEDOUT')) {
       return true
     }
 


### PR DESCRIPTION
# fix: broaden engines for v1.x and detect august-yale TimeoutError

## :recycle: Current situation

**Homebridge v1.x warning.** The Matter PR changed `engines.homebridge` to `"^2.0.0-beta.89"`, so v1.x users see a warning on every startup. The Matter code already handles v1.x gracefully at runtime via `api.isMatterAvailable?.()` — the engines field is just too restrictive.

**Timeouts never trigger session refresh.** august-yale v1.1.5 added request timeouts that throw `TimeoutError` with `name: 'TimeoutError'` and `message: 'Request timed out after 30000ms'`. But `isTimeoutError()` only checked `error.message.includes('ETIMEDOUT')` - a different string. So timeouts were detected and logged but never triggered a session refresh.

## :bulb: Proposed solution

**Patch 1:** Change `engines.homebridge` to `"^1.8.0 || ^2.0.0-beta.0"`.

**Patch 2:** Check `error.name === 'TimeoutError'` in `isTimeoutError()` as the primary detection mechanism. This is the stable contract from august-yale's exported `TimeoutError` class - works regardless of future message format changes. The existing `ETIMEDOUT` check is kept as a fallback for raw Node.js network errors that bypass august-yale's timeout wrapper.

After this fix, the recovery chain is:
1. Keep-alive connection goes stale → request times out after 30s
2. `isTimeoutError()` matches `error.name === 'TimeoutError'` → returns `true`
3. `refreshAugustSession()` fires (protected by 5-minute cooldown)
4. Old `August` instance destroyed → stale connections released
5. New `August` instance created → fresh TCP connections
6. Next poll succeeds

## :gear: Release Notes

- Homebridge v1.x users no longer see a version warning on startup.
- Timeouts from the August API now properly trigger session refresh and automatic recovery, fixing a bug where the plugin would stop communicating with locks after extended runtime until manually restarted.

## :heavy_plus_sign: Additional Information

### Testing

- new tests covering `error.name`-based detection