### PR TITLE
fix(platform): use august-yale's typed exceptions for error classification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@homebridge-plugins/homebridge-august",
-      "version": "3.1.2",
+      "version": "3.1.4",
       "funding": [
         {
           "type": "Paypal",
@@ -20,7 +20,7 @@
       "license": "ISC",
       "dependencies": {
         "@homebridge/plugin-ui-utils": "^2.2.3",
-        "august-yale": "^1.1.8",
+        "august-yale": "^1.2.0",
         "rxjs": "^7.8.2"
       },
       "devDependencies": {
@@ -795,9 +795,9 @@
       }
     },
     "node_modules/@homebridge/ciao": {
-      "version": "1.3.7-beta.1",
-      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.7-beta.1.tgz",
-      "integrity": "sha512-WM04XGrTKK43pW3iZvgoENJQNey5xBl2QENmU6aNWxMkpCvfvKu4X5CoycOkGhfwjG2YiwzGr4pDdkriF0x+Mw==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.7.tgz",
+      "integrity": "sha512-ncvcXQe4vrqBLNqnVjQjke5NpNin6SO9bStfBZ4jgZk/xIjD9GMcH8vp8XKd7hw5akIzwITMiDMysIKvE5rHBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -829,13 +829,13 @@
       }
     },
     "node_modules/@homebridge/hap-nodejs": {
-      "version": "2.1.3-beta.1",
-      "resolved": "https://registry.npmjs.org/@homebridge/hap-nodejs/-/hap-nodejs-2.1.3-beta.1.tgz",
-      "integrity": "sha512-1PLNe8E4u0L5NMvVIxutS1ujZKVPYAvTjEZ/Vc23khI2p6UO07RkkWU36tADNYevjX5n+d18nPOXg5Y2s8FdsQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@homebridge/hap-nodejs/-/hap-nodejs-2.1.3.tgz",
+      "integrity": "sha512-8TGtfgV4bY6VexoaoANxEaV2N0fLHO6I3aD65Bj4q6hGbwmXrkok4b9rxPjkOZOj77I8fhVQ2ofkeNrGBgdXVw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@homebridge/ciao": "^1.3.7-beta.0",
+        "@homebridge/ciao": "^1.3.7",
         "@homebridge/dbus-native": "^0.7.4",
         "bonjour-hap": "^3.10.1",
         "debug": "^4.4.3",
@@ -857,25 +857,39 @@
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -1048,9 +1062,9 @@
       "license": "MIT"
     },
     "node_modules/@matter/general": {
-      "version": "0.17.0-alpha.0-20260422-79d4eee90",
-      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.0-alpha.0-20260422-79d4eee90.tgz",
-      "integrity": "sha512-kZLk//a4D2wyKOm/GEnn9sbUQ5U9xnsvPvw/TsZDZhTaowdMm5ez/tkxIA98hU2sgrV0a3D2bE/HN3Stl0HWmA==",
+      "version": "0.17.0-alpha.0-20260426-5bf9dab53",
+      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.0-alpha.0-20260426-5bf9dab53.tgz",
+      "integrity": "sha512-7i4uj8hHA41dDpb7x1F2M60pp+qHrosKXNEqlquuSyPw1XmzZHhiayjnFY+mhrGKUbZMj8WttXd7MERrA0Rvmg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1058,83 +1072,83 @@
       }
     },
     "node_modules/@matter/main": {
-      "version": "0.17.0-alpha.0-20260422-79d4eee90",
-      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.0-alpha.0-20260422-79d4eee90.tgz",
-      "integrity": "sha512-KMKi4hf3sncOr3QiXQnR3VuN/Tm9PaYPEDsU852VY2ISCcgfW/MH4+ulSB706dIS1VgYsmkSVTvIgmBdj6wG9g==",
+      "version": "0.17.0-alpha.0-20260426-5bf9dab53",
+      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.0-alpha.0-20260426-5bf9dab53.tgz",
+      "integrity": "sha512-DtczQ1/EhHHp2FPHKnI4HwLZYC+jJz+TXVrsyonHQMSwZE5KANVa0XedTWHb08hhNgcWSrnUBWRwnP0tcnvu/g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.0-alpha.0-20260422-79d4eee90",
-        "@matter/model": "0.17.0-alpha.0-20260422-79d4eee90",
-        "@matter/node": "0.17.0-alpha.0-20260422-79d4eee90",
-        "@matter/protocol": "0.17.0-alpha.0-20260422-79d4eee90",
-        "@matter/types": "0.17.0-alpha.0-20260422-79d4eee90"
+        "@matter/general": "0.17.0-alpha.0-20260426-5bf9dab53",
+        "@matter/model": "0.17.0-alpha.0-20260426-5bf9dab53",
+        "@matter/node": "0.17.0-alpha.0-20260426-5bf9dab53",
+        "@matter/protocol": "0.17.0-alpha.0-20260426-5bf9dab53",
+        "@matter/types": "0.17.0-alpha.0-20260426-5bf9dab53"
       },
       "optionalDependencies": {
-        "@matter/nodejs": "0.17.0-alpha.0-20260422-79d4eee90"
+        "@matter/nodejs": "0.17.0-alpha.0-20260426-5bf9dab53"
       }
     },
     "node_modules/@matter/model": {
-      "version": "0.17.0-alpha.0-20260422-79d4eee90",
-      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.0-alpha.0-20260422-79d4eee90.tgz",
-      "integrity": "sha512-6XUn4qsQGWrcSoep8Zf19nB0HqirOA0ca4GGhQNh5V7/Ohx+DbTPcP87H87DUEJJTBIKrDoiaWwcuC/gIuhN/Q==",
+      "version": "0.17.0-alpha.0-20260426-5bf9dab53",
+      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.0-alpha.0-20260426-5bf9dab53.tgz",
+      "integrity": "sha512-nxeOPu2CR3X89jy7rDqnQs2V1b5hSDFKOI9tBujWNZMzyCnP6jW3WdIDLP4iMXuX8UTbSX1b9iQwASWUjFosqA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.0-alpha.0-20260422-79d4eee90"
+        "@matter/general": "0.17.0-alpha.0-20260426-5bf9dab53"
       }
     },
     "node_modules/@matter/node": {
-      "version": "0.17.0-alpha.0-20260422-79d4eee90",
-      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.0-alpha.0-20260422-79d4eee90.tgz",
-      "integrity": "sha512-w1HYJ7XcQk0n7ngSpcW3VLmJwnypVWf0E4yMsK3b72FC1K/ZbVXBPrNC7DH+PnnQOKFzyP0jGqrDPPrEJ4VA6Q==",
+      "version": "0.17.0-alpha.0-20260426-5bf9dab53",
+      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.0-alpha.0-20260426-5bf9dab53.tgz",
+      "integrity": "sha512-apXXiPBaH3bvhZZvG7LKb1onhposNJtg8yRjk7O/3i40rjuLNV/UnbCXCmBWJihRfWxOikn5yQ2oiy/gt62+xw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.0-alpha.0-20260422-79d4eee90",
-        "@matter/model": "0.17.0-alpha.0-20260422-79d4eee90",
-        "@matter/protocol": "0.17.0-alpha.0-20260422-79d4eee90",
-        "@matter/types": "0.17.0-alpha.0-20260422-79d4eee90"
+        "@matter/general": "0.17.0-alpha.0-20260426-5bf9dab53",
+        "@matter/model": "0.17.0-alpha.0-20260426-5bf9dab53",
+        "@matter/protocol": "0.17.0-alpha.0-20260426-5bf9dab53",
+        "@matter/types": "0.17.0-alpha.0-20260426-5bf9dab53"
       }
     },
     "node_modules/@matter/nodejs": {
-      "version": "0.17.0-alpha.0-20260422-79d4eee90",
-      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.0-alpha.0-20260422-79d4eee90.tgz",
-      "integrity": "sha512-J2Zg7C+mLiWF7uZ6d3BEKx04gI84zyZUJlxm6NdWn2UvUWUty6VcvwXS6cXlUUT2jzYThZ/wE0WcBZHAcQRDkQ==",
+      "version": "0.17.0-alpha.0-20260426-5bf9dab53",
+      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.0-alpha.0-20260426-5bf9dab53.tgz",
+      "integrity": "sha512-5vzh9gPbRM66bdarnwAOG4w/Xht9RC7Tuh+ZWllaW8hzTAMf0ZNTP73H+mNSUu7mqCPG5raecPvCyeJGXXK1xQ==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@matter/general": "0.17.0-alpha.0-20260422-79d4eee90",
-        "@matter/node": "0.17.0-alpha.0-20260422-79d4eee90",
-        "@matter/protocol": "0.17.0-alpha.0-20260422-79d4eee90",
-        "@matter/types": "0.17.0-alpha.0-20260422-79d4eee90"
+        "@matter/general": "0.17.0-alpha.0-20260426-5bf9dab53",
+        "@matter/node": "0.17.0-alpha.0-20260426-5bf9dab53",
+        "@matter/protocol": "0.17.0-alpha.0-20260426-5bf9dab53",
+        "@matter/types": "0.17.0-alpha.0-20260426-5bf9dab53"
       },
       "engines": {
         "node": ">=20.19.0 <22.0.0 || >=22.13.0"
       }
     },
     "node_modules/@matter/protocol": {
-      "version": "0.17.0-alpha.0-20260422-79d4eee90",
-      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.0-alpha.0-20260422-79d4eee90.tgz",
-      "integrity": "sha512-D4PJB/B5VcaUXiZq70AzVMXwsgyZdvkN8XCaZI3Hj95zP/nqkq/Rn1mOtmTgrTogBob0oxWKzz8aooApijqbqw==",
+      "version": "0.17.0-alpha.0-20260426-5bf9dab53",
+      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.0-alpha.0-20260426-5bf9dab53.tgz",
+      "integrity": "sha512-nNGrWdEbtfoQIQQn9AIFcAOlv1p1fcwnpDSHukZrnujA4WAbgv/dIEC0eRQb9Fvc2DRDpLpyNhfTdlD+T4gTxA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.0-alpha.0-20260422-79d4eee90",
-        "@matter/model": "0.17.0-alpha.0-20260422-79d4eee90",
-        "@matter/types": "0.17.0-alpha.0-20260422-79d4eee90"
+        "@matter/general": "0.17.0-alpha.0-20260426-5bf9dab53",
+        "@matter/model": "0.17.0-alpha.0-20260426-5bf9dab53",
+        "@matter/types": "0.17.0-alpha.0-20260426-5bf9dab53"
       }
     },
     "node_modules/@matter/types": {
-      "version": "0.17.0-alpha.0-20260422-79d4eee90",
-      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.0-alpha.0-20260422-79d4eee90.tgz",
-      "integrity": "sha512-I2EMsCRr/9vX5u2lN9FVAoVD6yXm4cgcOCzpguS1IyI5VWuePBJ0h0hDxaaL3+c48ETu5dKojE3FHiR9cD9xvw==",
+      "version": "0.17.0-alpha.0-20260426-5bf9dab53",
+      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.0-alpha.0-20260426-5bf9dab53.tgz",
+      "integrity": "sha512-HxlIVaUIDrVXr167xYm7jKI+9L3EIGvABIDP/ch6t1gGXIerl0IjiOemKt3EyfLZsHQ2LGo7bWaOAISlF04m/w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.0-alpha.0-20260422-79d4eee90",
-        "@matter/model": "0.17.0-alpha.0-20260422-79d4eee90"
+        "@matter/general": "0.17.0-alpha.0-20260426-5bf9dab53",
+        "@matter/model": "0.17.0-alpha.0-20260426-5bf9dab53"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -2267,17 +2281,17 @@
       "peer": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
-      "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.1.tgz",
+      "integrity": "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/type-utils": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/scope-manager": "8.59.1",
+        "@typescript-eslint/type-utils": "8.59.1",
+        "@typescript-eslint/utils": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -2290,22 +2304,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.58.2",
+        "@typescript-eslint/parser": "^8.59.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
-      "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
+      "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/scope-manager": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2321,14 +2335,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
-      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
+      "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.2",
-        "@typescript-eslint/types": "^8.58.2",
+        "@typescript-eslint/tsconfig-utils": "^8.59.1",
+        "@typescript-eslint/types": "^8.59.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2343,16 +2357,16 @@
       }
     },
     "node_modules/@typescript-eslint/rule-tester": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/rule-tester/-/rule-tester-8.58.2.tgz",
-      "integrity": "sha512-HF7ry5ZhQSLn4JAJfQCPX39D6BE5MhYXE743I0phrJw1BvB0adH8JpsEc4owCxEESQflodyhRWNUZY+m2EVenw==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/rule-tester/-/rule-tester-8.59.1.tgz",
+      "integrity": "sha512-VAlTRylRP+zh2jepYylwEllQSI8yP0QWQqUKc3xcPbuSlnDeC0CjbpWAOp5CrqfGl9ZMGw74BjZnutb7mILOzA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/parser": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2",
+        "@typescript-eslint/parser": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1",
+        "@typescript-eslint/utils": "8.59.1",
         "ajv": "^6.12.6",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "4.6.2",
@@ -2370,14 +2384,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
-      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
+      "integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2"
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2388,9 +2402,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
-      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
+      "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2405,15 +2419,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
-      "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.1.tgz",
+      "integrity": "sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1",
+        "@typescript-eslint/utils": "8.59.1",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2430,9 +2444,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
-      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
+      "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2444,16 +2458,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
-      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
+      "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.2",
-        "@typescript-eslint/tsconfig-utils": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/project-service": "8.59.1",
+        "@typescript-eslint/tsconfig-utils": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2472,16 +2486,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
-      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.1.tgz",
+      "integrity": "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2"
+        "@typescript-eslint/scope-manager": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2496,13 +2510,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
-      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
+      "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/types": "8.59.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2712,67 +2726,67 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.32.tgz",
-      "integrity": "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.33.tgz",
+      "integrity": "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@vue/shared": "3.5.32",
+        "@vue/shared": "3.5.33",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.32.tgz",
-      "integrity": "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
+      "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@vue/compiler-core": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/compiler-core": "3.5.33",
+        "@vue/shared": "3.5.33"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.32.tgz",
-      "integrity": "sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.33.tgz",
+      "integrity": "sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@vue/compiler-core": "3.5.32",
-        "@vue/compiler-dom": "3.5.32",
-        "@vue/compiler-ssr": "3.5.32",
-        "@vue/shared": "3.5.32",
+        "@vue/compiler-core": "3.5.33",
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/compiler-ssr": "3.5.33",
+        "@vue/shared": "3.5.33",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
-        "postcss": "^8.5.8",
+        "postcss": "^8.5.10",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.32.tgz",
-      "integrity": "sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.33.tgz",
+      "integrity": "sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/shared": "3.5.33"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.32.tgz",
-      "integrity": "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.33.tgz",
+      "integrity": "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -2875,9 +2889,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3033,9 +3047,9 @@
       "license": "MIT"
     },
     "node_modules/august-yale": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/august-yale/-/august-yale-1.1.8.tgz",
-      "integrity": "sha512-qAK7+Pp8XSB4rVbb9J7gtR0qR5uHQdOHxpJWYvpCXUmiOhUfNMLUWrpsrYqZXpnbDRzMlP8sgO5v1T32lw9tug==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/august-yale/-/august-yale-1.2.0.tgz",
+      "integrity": "sha512-KbdGgL+psgNduZQL5faUr4CR0GWzGCnmX8smwimcw+fxLaYO4U9IqlGnnCmf9hSWQtBvTRnLWateVqodkc76NQ==",
       "funding": [
         {
           "type": "Paypal - donavanbecker",
@@ -3096,9 +3110,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
-      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
+      "version": "2.10.24",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
+      "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -3108,9 +3122,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -3296,9 +3310,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001788",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
-      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -3833,9 +3847,9 @@
       "peer": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.339",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.339.tgz",
-      "integrity": "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg==",
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -3876,14 +3890,14 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
-      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
+      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -3932,9 +3946,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4455,9 +4469,9 @@
       }
     },
     "node_modules/eslint-plugin-no-only-tests": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.3.0.tgz",
-      "integrity": "sha512-brcKcxGnISN2CcVhXJ/kEQlNa0MEfGRtwKtWA16SkqXHKitaKIMrfemJKLKX1YqDU5C/5JY3PvZXd5jEW04e0Q==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.4.0.tgz",
+      "integrity": "sha512-4S3/9Nb7A2tiMcpzEQE9bQSlpeOz6WJkgryBuou/SA8W2x2c8Zf4j0NvTKBjv6qNhF9T79tmkecm/0CHqV0UGg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4606,9 +4620,9 @@
       }
     },
     "node_modules/eslint-plugin-vue": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.8.0.tgz",
-      "integrity": "sha512-f1J/tcbnrpgC8suPN5AtdJ5MQjuXbSU9pGRSSYAuF3SHoiYCOdEX6O22pLaRyLHXvDcOe+O5ENgc1owQ587agA==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.9.0.tgz",
+      "integrity": "sha512-EFNNzu4HqtTRb5DJINpyd+u3bDdzETWDMpCzG+UBHz1tpsnMDCeOcf61u4Wy/cbXnMymK+MT9bjH7KcG1fItSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5585,9 +5599,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5634,14 +5648,14 @@
       }
     },
     "node_modules/homebridge": {
-      "version": "2.0.0-beta.101",
-      "resolved": "https://registry.npmjs.org/homebridge/-/homebridge-2.0.0-beta.101.tgz",
-      "integrity": "sha512-vZaVjADQ8NFbpy76OoMCPTxa1aTCA14+vVmafAR3yPxs7f8t6pwLuTvvz+rRuB3Myc8zgx7o7rN+8ZRH/CCPhQ==",
+      "version": "2.0.0-beta.104",
+      "resolved": "https://registry.npmjs.org/homebridge/-/homebridge-2.0.0-beta.104.tgz",
+      "integrity": "sha512-nVK7BzRcpab8bAEdhZxDIXDkm5GjIBmsaqG3IGM/Cg/uF/M6DC1/sGv7N/radf7zZy6JIIN/e0cXjpPIi1hHuw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@homebridge/hap-nodejs": "2.1.3-beta.1",
-        "@matter/main": "0.17.0-alpha.0-20260422-79d4eee90",
+        "@homebridge/hap-nodejs": "2.1.3",
+        "@matter/main": "0.17.0-alpha.0-20260426-5bf9dab53",
         "chalk": "5.6.2",
         "commander": "14.0.3",
         "fs-extra": "11.3.4",
@@ -5850,9 +5864,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
+      "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -6304,9 +6318,9 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8501,9 +8515,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "license": "MIT"
     },
     "node_modules/nodemon": {
@@ -8930,14 +8944,14 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
-      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "confbox": "^0.2.2",
-        "exsolve": "^1.0.7",
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
       }
     },
@@ -8972,9 +8986,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {
@@ -9884,12 +9898,12 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
+      "integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -10126,9 +10140,9 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
-      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10194,9 +10208,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10448,9 +10462,9 @@
       "license": "MIT"
     },
     "node_modules/ufo": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
-      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@homebridge/plugin-ui-utils": "^2.2.3",
-    "august-yale": "^1.1.8",
+    "august-yale": "^1.2.0",
     "rxjs": "^7.8.2"
   },
   "devDependencies": {

--- a/src/connectivity-manager.ts
+++ b/src/connectivity-manager.ts
@@ -45,7 +45,7 @@ import type { Logging } from 'homebridge'
 
 import type { credentials } from './settings.js'
 
-import August, { TimeoutError } from 'august-yale'
+import August, { AbortedError, InvalidAuth, NetworkError, TimeoutError } from 'august-yale'
 
 export type ConnectivityState = 'healthy' | 'degraded' | 'offline' | 'recovering'
 
@@ -58,17 +58,6 @@ const BACKOFF_SCHEDULE_MS = [5_000, 10_000, 20_000, 40_000, 80_000, 160_000, 300
 
 /** Probe timeout — short on purpose. A healthy August API responds in <1s. */
 const PROBE_TIMEOUT_MS = 8_000
-
-/** Network error codes that classify() treats as connectivity failures. */
-const NETWORK_ERROR_CODES = new Set([
-  'ECONNRESET',
-  'ENETUNREACH',
-  'EHOSTUNREACH',
-  'ENOTFOUND',
-  'ECONNREFUSED',
-  'EAI_AGAIN',
-  'ETIMEDOUT',
-])
 
 type ErrorKind = 'network' | 'auth' | 'transient'
 
@@ -300,21 +289,51 @@ export class ConnectivityManager {
   }
 
   private classify(e: unknown): ErrorKind {
-    const err = e as { name?: string, statusCode?: number, code?: string, message?: string }
-    if (err?.name === 'TimeoutError') {
+    // august-yale wraps every transport-level fetch failure into one of
+    // its typed exceptions before the error reaches us. We rely on those
+    // types here rather than re-implementing undici's 24-class taxonomy.
+    //
+    // - NetworkError (and its TimeoutError subclass) covers connect
+    //   timeouts, socket resets, headers/body timeouts, DNS failures,
+    //   TLS proxy failures, malformed responses, etc.
+    //
+    // - AbortedError reflects an in-flight request racing with our own
+    //   teardown (e.g. during rebuildClient). NOT 'network': the consumer
+    //   intent was to tear down, so we don't want this to drive the
+    //   state machine into degraded.
+    //
+    // - InvalidAuth is august-yale's auth-failure type. Maps to 'auth'.
+    //
+    // Anything else (including programmer errors and server-answered
+    // 4xx/5xx that august-yale leaves unwrapped) is 'transient' — bubble
+    // back to the caller, don't change connectivity state.
+    if (e instanceof NetworkError) {
       return 'network'
     }
-    if (err?.code && NETWORK_ERROR_CODES.has(err.code)) {
+    if (e instanceof AbortedError) {
+      return 'transient'
+    }
+    if (e instanceof TimeoutError) {
+      // Defensive: TimeoutError is also a NetworkError so the first
+      // check should match. Kept for clarity in case of future
+      // exception hierarchy changes upstream.
       return 'network'
     }
-    if (err?.message && /ETIMEDOUT|ECONNRESET|ENOTFOUND|ENETUNREACH/i.test(err.message)) {
-      return 'network'
+    if (e instanceof InvalidAuth) {
+      return 'auth'
     }
-    if (err?.statusCode === 502 || err?.statusCode === 503 || err?.statusCode === 504) {
-      return 'network'
-    }
+
+    // Fallback for HTTP-level errors that august-yale leaves unwrapped
+    // (e.g. server answered with a non-2xx without bare-401 semantics).
+    const err = e as { statusCode?: number }
     if (err?.statusCode === 401) {
       return 'auth'
+    }
+    if (err?.statusCode === 502 || err?.statusCode === 503 || err?.statusCode === 504) {
+      // 5xx responses where the server is reachable but reporting an
+      // upstream issue. Treat as network — these are recoverable by
+      // waiting and retrying (matches the state-machine semantic).
+      return 'network'
     }
     return 'transient'
   }

--- a/test/connectivity-manager.test.ts
+++ b/test/connectivity-manager.test.ts
@@ -17,12 +17,43 @@ import { ConnectivityManager, OfflineError } from '../src/connectivity-manager.j
 
 // Mock the august-yale module. We need:
 //   - August: a constructor we can instantiate, with details() and destroy()
-//   - TimeoutError: a real error class so `name === 'TimeoutError'` works
+//   - The full exception hierarchy that classify() now uses for routing:
+//     NetworkError, TimeoutError (subclass), AbortedError, InvalidAuth.
 vi.mock('august-yale', () => {
-  class TimeoutError extends Error {
-    constructor(message?: string) {
+  class YaleApiError extends Error {
+    public originalError?: Error
+    constructor(message?: string, originalError?: Error) {
       super(message)
+      this.name = 'YaleApiError'
+      this.originalError = originalError
+    }
+  }
+  class NetworkError extends YaleApiError {
+    public code?: string
+    constructor(message?: string, originalError?: Error, code?: string) {
+      super(message, originalError)
+      this.name = 'NetworkError'
+      this.code = code
+    }
+  }
+  class TimeoutError extends NetworkError {
+    constructor(message?: string, originalError?: Error, code?: string) {
+      super(message, originalError, code)
       this.name = 'TimeoutError'
+    }
+  }
+  class AbortedError extends YaleApiError {
+    public code?: string
+    constructor(message?: string, originalError?: Error, code?: string) {
+      super(message, originalError)
+      this.name = 'AbortedError'
+      this.code = code
+    }
+  }
+  class InvalidAuth extends YaleApiError {
+    constructor(message?: string, originalError?: Error) {
+      super(message, originalError)
+      this.name = 'InvalidAuth'
     }
   }
   // Each new August() returns a unique object so tests can assert which
@@ -43,7 +74,11 @@ vi.mock('august-yale', () => {
   })
   return {
     default: MockAugust,
+    YaleApiError,
+    NetworkError,
     TimeoutError,
+    AbortedError,
+    InvalidAuth,
   }
 })
 
@@ -188,23 +223,57 @@ describe('ConnectivityManager', () => {
       expect(m.getState()).toBe('degraded')
     })
 
-    it('treats 502/503/504 as network errors', async () => {
+    it('treats NetworkError as network and transitions to degraded', async () => {
+      // NetworkError covers all transport-level failures from august-yale —
+      // socket reset, DNS failure, malformed response, etc. — without us
+      // having to enumerate undici's 24 error classes.
+      const m = new ConnectivityManager(makeLog(), fakeCredentials)
+      await m.init()
+      const { NetworkError } = await import('august-yale')
+      const result = await m.execute('test', async () => { throw new NetworkError('socket hang up', undefined, 'ECONNRESET') })
+      expect(result).toBeUndefined()
+      expect(m.getState()).toBe('degraded')
+    })
+
+    it('treats InvalidAuth as auth and rebuilds without changing state', async () => {
+      const onClientChanged = vi.fn()
+      const m = new ConnectivityManager(makeLog(), fakeCredentials, onClientChanged)
+      await m.init()
+      expect(onClientChanged).toHaveBeenCalledTimes(1)
+      const { InvalidAuth } = await import('august-yale')
+      const result = await m.execute('test', async () => { throw new InvalidAuth('session expired') })
+      expect(result).toBeUndefined()
+      await vi.runAllTimersAsync()
+      expect(onClientChanged).toHaveBeenCalledTimes(2)
+      expect(m.getState()).toBe('healthy')
+    })
+
+    it('treats AbortedError as transient and does NOT change connectivity state', async () => {
+      // AbortedError reflects a request racing with our own teardown
+      // (e.g. inside rebuildClient). Treating it as 'network' would
+      // make the state machine fight itself: every rebuild produces
+      // ClientDestroyedError -> degraded -> probe -> rebuild ->
+      // ClientDestroyedError -> ...
+      const m = new ConnectivityManager(makeLog(), fakeCredentials)
+      await m.init()
+      const { AbortedError } = await import('august-yale')
+      const err = new AbortedError('client destroyed', undefined, 'UND_ERR_DESTROYED')
+      await expect(
+        m.execute('test', async () => { throw err }),
+      ).rejects.toBe(err)
+      // State stays healthy — no probe scheduled.
+      expect(m.getState()).toBe('healthy')
+    })
+
+    it('treats 502/503/504 as network errors (HTTP-level fallback)', async () => {
+      // Most transport failures are now wrapped upstream as NetworkError,
+      // but if august-yale ever surfaces a clean HTTP 5xx response, we
+      // still want to recognize 502/503/504 as network-class and probe.
       const m = new ConnectivityManager(makeLog(), fakeCredentials)
       await m.init()
       const err = Object.assign(new Error('Bad Gateway'), { statusCode: 502 })
       await m.execute('test', async () => { throw err })
       expect(m.getState()).toBe('degraded')
-    })
-
-    it('treats ECONNRESET / ENETUNREACH / ENOTFOUND as network errors', async () => {
-      for (const code of ['ECONNRESET', 'ENETUNREACH', 'ENOTFOUND', 'ECONNREFUSED']) {
-        const m = new ConnectivityManager(makeLog(), fakeCredentials)
-        await m.init()
-        const err = Object.assign(new Error(code), { code })
-        await m.execute('test', async () => { throw err })
-        expect(m.getState(), `code=${code}`).toBe('degraded')
-        m.shutdown()
-      }
     })
   })
 


### PR DESCRIPTION
## :recycle: Current situation

After the connectivity-recovery refactor, the
`ConnectivityManager` had its own `classify()` method that inspected
errors by `err.code`, `err.name`, `err.message`, and `err.statusCode`
to decide whether to treat them as `network`, `auth`, or `transient`.

Production failure: in undici 7+, every fetch failure is wrapped in a
generic `TypeError("fetch failed")` with the real cause one level
deeper at `err.cause`. The old classifier only inspected level 0:

- `err.code` → undefined (TypeError has no code)
- `err.name` → 'TypeError' (not in any of our match sets)
- `err.message` → 'fetch failed' (regex misses)
- `err.statusCode` → undefined

Every signal missed. The error fell through to `'transient'`, the
state machine never engaged, and the plugin logged
`Polling tick failed: fetch failed` every poll cycle for hours after
a router blip without recovering. The exact symptom the
ConnectivityManager exists to prevent.

Fixing this in `homebridge-august` would mean re-implementing
undici's full 24-class error taxonomy here. That belongs in the
transport layer (see homebridge-plugins/august-yale) which adds
typed exceptions (`NetworkError`, `AbortedError`, with `TimeoutError`
re-parented as a `NetworkError` subclass).

## :bulb: Proposed solution

With august-yale doing the wrapping upstream, the classifier in
`ConnectivityManager` collapses to three `instanceof` checks:

```ts
if (e instanceof NetworkError) return 'network'
if (e instanceof AbortedError) return 'transient'
if (e instanceof InvalidAuth)  return 'auth'
```

Plus two HTTP-level fallbacks for the case where august-yale ever
surfaces a clean HTTP response error unwrapped (401 → auth,
502/503/504 → network).

The `NETWORK_ERROR_CODES` set is removed entirely — that's
august-yale's responsibility now. The brittle regex on
`err.message` is gone. The classifier is structural rather than
pattern-based, so it can't drift out of sync with future undici
releases.

`AbortedError` getting its own classification is meaningful: it
reflects an in-flight request racing with our own teardown (e.g.
inside `rebuildClient`). Treating it as `'network'` would make the
state machine fight itself: every rebuild produces a
ClientDestroyedError, classifier reports network, state goes to
degraded, probe scheduled, probe succeeds, rebuild, ClientDestroyedError
again, ... With `AbortedError → transient`, intentional teardowns are
swallowed cleanly.

## :gear: Release Notes

Fixes connectivity-recovery failures on undici 7+: after a transient
network outage (router restart, ISP blip, sleep/wake), the plugin now
correctly enters `degraded` state, schedules a probe, rebuilds the
client on probe success, and returns to `healthy` - matching the
behavior the ConnectivityManager was designed to provide.

Bumps `august-yale` dependency to `^1.2.0` (the version that adds
`NetworkError` / `AbortedError`).

## :heavy_plus_sign: Additional Information

### Testing

Suite goes 84 → 86 (+3 new, –1 removed).

### Reviewer Nudging
