### PR TITLE
Fix/connectivity recovery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       "license": "ISC",
       "dependencies": {
         "@homebridge/plugin-ui-utils": "^2.2.3",
-        "august-yale": "^1.2.0",
+        "august-yale": "^1.2.1",
         "rxjs": "^7.8.2"
       },
       "devDependencies": {
@@ -3047,9 +3047,9 @@
       "license": "MIT"
     },
     "node_modules/august-yale": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/august-yale/-/august-yale-1.2.0.tgz",
-      "integrity": "sha512-KbdGgL+psgNduZQL5faUr4CR0GWzGCnmX8smwimcw+fxLaYO4U9IqlGnnCmf9hSWQtBvTRnLWateVqodkc76NQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/august-yale/-/august-yale-1.2.1.tgz",
+      "integrity": "sha512-A5E6FLbr5gIIa7ylECLTiHTpWPrMPOuBrq9qLz2Rpah41G2zh4K3ReF6yr0P8JrEIp4Mcfm2e7Z5BiPv4XRLbg==",
       "funding": [
         {
           "type": "Paypal - donavanbecker",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@homebridge/plugin-ui-utils": "^2.2.3",
-    "august-yale": "^1.2.0",
+    "august-yale": "^1.2.1",
     "rxjs": "^7.8.2"
   },
   "devDependencies": {

--- a/src/connectivity-manager.ts
+++ b/src/connectivity-manager.ts
@@ -270,59 +270,62 @@ export class ConnectivityManager {
   private async runProbe(): Promise<void> {
     this.probeAttempts++
 
-    // Build a FRESH client just for the probe.
-    //
-    // The previous design probed against the existing client to "avoid
-    // an Agent born into a broken network". That logic was wrong for
-    // the case it was meant to protect against: when the network
-    // recovers but the existing Agent still holds stale half-open
-    // sockets from before the outage. Probes against the existing
-    // client kept failing on those stale sockets, so the system stayed
-    // offline indefinitely even after the network came back. The
-    // PubNub-triggered immediate probe didn't help either, because it
-    // used the same stale Agent.
-    //
-    // A fresh client per probe attempt avoids the trap. If the network
-    // is genuinely down, the fresh probe fails the same way the old
-    // probe would have (no false-positive recovery). If the network is
-    // back, the fresh probe gets a clean dispatcher and succeeds.
-    let probeClient: August
-    try {
-      probeClient = new August(await this.credentialsFactory())
-    } catch (e: any) {
-      this.lastFailureMessage = `probe-build: ${e?.message ?? e}`
-      this.log.warn(`Connectivity: probe attempt #${this.probeAttempts} couldn't build client: ${e?.message ?? e}`)
-      this.scheduleProbe()
-      return
+    let client = this.client
+    if (!client) {
+      // No client at all — rebuild from credentials. This branch is
+      // hit only at startup if init() hasn't completed; in steady
+      // state we always have a client.
+      this.log.warn(`Connectivity: probe attempt #${this.probeAttempts} — no client to probe; trying to (re)build`)
+      try {
+        await this.rebuildClient('probe with no client')
+      } catch (e: any) {
+        this.lastFailureMessage = `probe-build: ${e?.message ?? e}`
+        this.scheduleProbe()
+        return
+      }
+      client = this.client
+      if (!client) {
+        // rebuildClient resolved but didn't actually populate this.client.
+        // Defensive: don't proceed without a client; reschedule and try
+        // again on the next backoff slot.
+        this.lastFailureMessage = 'probe-build: rebuildClient produced no client'
+        this.scheduleProbe()
+        return
+      }
     }
+
+    // Reset the transport BEFORE probing.
+    //
+    // The previous implementation probed against the existing client's
+    // socket pool. That pool may hold stale half-open sockets from
+    // before the outage; probing against them just keeps failing on
+    // dead connections, so the system stayed offline even after the
+    // network had recovered. The PubNub-triggered immediate probe
+    // hit the same wall.
+    //
+    // resetTransport() throws away the dispatcher and creates a fresh
+    // one without losing auth state, the session token, or
+    // configuration. Distinct from destroy() + new August() — that
+    // would force a re-auth round-trip on the next call, which itself
+    // can fail on a still-flaky network and leave us stuck. With just
+    // a transport reset, the next request gets a clean connection
+    // pool and reuses the cached session token; if it succeeds, we're
+    // healthy in one round-trip.
+    client.resetTransport()
 
     this.log.info(`Connectivity: probe attempt #${this.probeAttempts} (state=${this.state})`)
 
     try {
       await Promise.race([
-        probeClient.locks(),
+        client.locks(),
         new Promise((_resolve, reject) =>
           setTimeout(() => reject(new TimeoutError('probe timed out')), PROBE_TIMEOUT_MS),
         ),
       ])
-      // Probe succeeded against the fresh client — adopt it as the
-      // current client. This is the rebuild path; no separate
-      // rebuildClient() call is needed afterward.
-      const old = this.client
-      this.client = probeClient
-      this.onClientChanged(this.client)
-      old?.destroy()
-      this.log.info(`Connectivity: probe attempt #${this.probeAttempts} succeeded — rebuilt client`)
+      this.log.info(`Connectivity: probe attempt #${this.probeAttempts} succeeded`)
       this.transitionTo('healthy')
       this.backoffIndex = 0
     } catch (e: any) {
-      // Probe failed — discard the temp client cleanly so we don't leak
-      // an Agent on every attempt.
-      try {
-        probeClient.destroy()
-      } catch {
-        // best-effort
-      }
       this.lastFailureMessage = `${this.classify(e)}: ${e?.message ?? e}`
       if (this.state !== 'offline') {
         this.log.warn('Connectivity: probe failed — entering offline state')

--- a/src/connectivity-manager.ts
+++ b/src/connectivity-manager.ts
@@ -59,6 +59,21 @@ const BACKOFF_SCHEDULE_MS = [5_000, 10_000, 20_000, 40_000, 80_000, 160_000, 300
 /** Probe timeout — short on purpose. A healthy August API responds in <1s. */
 const PROBE_TIMEOUT_MS = 8_000
 
+/**
+ * How often to emit a heartbeat log line while offline.
+ *
+ * Without it the log goes silent after the initial healthy → degraded →
+ * offline transition, making it impossible to distinguish "state machine
+ * is working hard, probes are failing every backoff slot" from "state
+ * machine is silently stuck". The heartbeat surfaces probe attempts and
+ * the most recent failure so future regressions are debuggable from the
+ * log alone.
+ *
+ * One hour matches the typical "I checked on it later" cadence; not so
+ * frequent it becomes log spam during a real ISP outage.
+ */
+const OFFLINE_HEARTBEAT_INTERVAL_MS = 60 * 60 * 1000
+
 type ErrorKind = 'network' | 'auth' | 'transient'
 
 interface ExecuteOptions {
@@ -81,9 +96,17 @@ export class ConnectivityManager {
   private state: ConnectivityState = 'healthy'
   private client?: August
   private probeTimer?: NodeJS.Timeout
+  private heartbeatTimer?: NodeJS.Timeout
   private backoffIndex = 0
   private rebuildInFlight?: Promise<void>
   private listeners = new Set<(next: ConnectivityState, prev: ConnectivityState) => void>()
+
+  // Diagnostic counters. Reset on transition out of offline. Used by the
+  // heartbeat log so an ongoing outage is visible in the log without
+  // having to trace per-probe details.
+  private offlineSinceMs?: number
+  private probeAttempts = 0
+  private lastFailureMessage?: string
 
   constructor(
     private readonly log: Logging,
@@ -165,7 +188,10 @@ export class ConnectivityManager {
     if (this.state === 'healthy') {
       return
     }
-    this.log.info('Connectivity: PubNub reconnect signal received — probing immediately')
+    const offlineFor = this.offlineSinceMs
+      ? ` (offline for ${Math.floor((Date.now() - this.offlineSinceMs) / 1000)}s)`
+      : ''
+    this.log.info(`Connectivity: PubNub reconnect signal received in ${this.state}${offlineFor} — probing immediately`)
     this.clearProbeTimer()
     void this.runProbe()
   }
@@ -196,6 +222,7 @@ export class ConnectivityManager {
 
   shutdown(): void {
     this.clearProbeTimer()
+    this.stopHeartbeat()
     this.client?.destroy()
     this.client = undefined
     this.onClientChanged(undefined)
@@ -241,26 +268,62 @@ export class ConnectivityManager {
   }
 
   private async runProbe(): Promise<void> {
-    if (!this.client) {
+    this.probeAttempts++
+
+    // Build a FRESH client just for the probe.
+    //
+    // The previous design probed against the existing client to "avoid
+    // an Agent born into a broken network". That logic was wrong for
+    // the case it was meant to protect against: when the network
+    // recovers but the existing Agent still holds stale half-open
+    // sockets from before the outage. Probes against the existing
+    // client kept failing on those stale sockets, so the system stayed
+    // offline indefinitely even after the network came back. The
+    // PubNub-triggered immediate probe didn't help either, because it
+    // used the same stale Agent.
+    //
+    // A fresh client per probe attempt avoids the trap. If the network
+    // is genuinely down, the fresh probe fails the same way the old
+    // probe would have (no false-positive recovery). If the network is
+    // back, the fresh probe gets a clean dispatcher and succeeds.
+    let probeClient: August
+    try {
+      probeClient = new August(await this.credentialsFactory())
+    } catch (e: any) {
+      this.lastFailureMessage = `probe-build: ${e?.message ?? e}`
+      this.log.warn(`Connectivity: probe attempt #${this.probeAttempts} couldn't build client: ${e?.message ?? e}`)
+      this.scheduleProbe()
       return
     }
+
+    this.log.info(`Connectivity: probe attempt #${this.probeAttempts} (state=${this.state})`)
+
     try {
-      // Cheap authenticated call against the EXISTING client. .locks()
-      // returns a small map and is the lightest endpoint. Race against a
-      // short timeout — the goal is "is the network working", not
-      // "is everything healthy".
       await Promise.race([
-        this.client.locks(),
+        probeClient.locks(),
         new Promise((_resolve, reject) =>
           setTimeout(() => reject(new TimeoutError('probe timed out')), PROBE_TIMEOUT_MS),
         ),
       ])
-      // Network is back. Rebuild the client to shed any half-open sockets
-      // accumulated before the outage, then mark healthy.
-      await this.rebuildClient('probe succeeded')
+      // Probe succeeded against the fresh client — adopt it as the
+      // current client. This is the rebuild path; no separate
+      // rebuildClient() call is needed afterward.
+      const old = this.client
+      this.client = probeClient
+      this.onClientChanged(this.client)
+      old?.destroy()
+      this.log.info(`Connectivity: probe attempt #${this.probeAttempts} succeeded — rebuilt client`)
       this.transitionTo('healthy')
       this.backoffIndex = 0
-    } catch {
+    } catch (e: any) {
+      // Probe failed — discard the temp client cleanly so we don't leak
+      // an Agent on every attempt.
+      try {
+        probeClient.destroy()
+      } catch {
+        // best-effort
+      }
+      this.lastFailureMessage = `${this.classify(e)}: ${e?.message ?? e}`
       if (this.state !== 'offline') {
         this.log.warn('Connectivity: probe failed — entering offline state')
         this.transitionTo('offline')
@@ -345,6 +408,20 @@ export class ConnectivityManager {
     }
     this.state = next
     this.log.info(`Connectivity: ${prev} -> ${next}`)
+
+    // Heartbeat lifecycle: start when entering offline, stop when leaving.
+    // offlineSinceMs is set on entry; probe-attempt count is NOT reset
+    // here because runProbe() already incremented it for the failure
+    // that triggered this transition.
+    if (next === 'offline') {
+      this.offlineSinceMs = Date.now()
+      this.startHeartbeat()
+    } else if (prev === 'offline') {
+      this.stopHeartbeat()
+      this.offlineSinceMs = undefined
+      this.probeAttempts = 0
+    }
+
     for (const l of this.listeners) {
       try {
         l(next, prev)
@@ -352,6 +429,36 @@ export class ConnectivityManager {
         this.log.error(`Connectivity listener threw: ${e?.message ?? e}`)
       }
     }
+  }
+
+  private startHeartbeat(): void {
+    this.stopHeartbeat()
+    this.heartbeatTimer = setInterval(() => this.emitHeartbeat(), OFFLINE_HEARTBEAT_INTERVAL_MS)
+    // Allow Node to exit if this is the only outstanding timer; we
+    // don't want the heartbeat to keep the process alive on shutdown.
+    if (typeof this.heartbeatTimer.unref === 'function') {
+      this.heartbeatTimer.unref()
+    }
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer)
+      this.heartbeatTimer = undefined
+    }
+  }
+
+  private emitHeartbeat(): void {
+    if (this.state !== 'offline' || this.offlineSinceMs === undefined) {
+      return
+    }
+    const minutes = Math.floor((Date.now() - this.offlineSinceMs) / 60000)
+    const lastFailure = this.lastFailureMessage ?? 'unknown'
+    this.log.warn(
+      `Connectivity: still offline after ${minutes} min — `
+      + `${this.probeAttempts} probe attempt${this.probeAttempts === 1 ? '' : 's'}, `
+      + `last failure: ${lastFailure}`,
+    )
   }
 
   private clearProbeTimer(): void {

--- a/test/connectivity-manager.test.ts
+++ b/test/connectivity-manager.test.ts
@@ -64,26 +64,16 @@ vi.mock('august-yale', () => {
   // eslint-disable-next-line prefer-arrow-callback
   const MockAugust = vi.fn().mockImplementation(function () {
     const id = ++nextId
-    const base: any = {
+    return {
       _id: id,
       details: vi.fn().mockResolvedValue({ ok: true }),
       locks: vi.fn().mockResolvedValue({}),
       lock: vi.fn().mockResolvedValue(undefined),
       unlock: vi.fn().mockResolvedValue(undefined),
       destroy: vi.fn(),
+      resetTransport: vi.fn(),
       end: vi.fn(),
     }
-    const override = (globalThis as any).__nextClientOverride
-    if (override) {
-      Object.assign(base, override)
-      // Stickiness: if the override has __sticky set, preserve it across
-      // multiple new August() calls. Used by the heartbeat tests where
-      // every probe in a sequence should fail.
-      if (!override.__sticky) {
-        ;(globalThis as any).__nextClientOverride = undefined
-      }
-    }
-    return base
   })
   return {
     default: MockAugust,
@@ -121,9 +111,6 @@ describe('ConnectivityManager', () => {
   afterEach(() => {
     vi.useRealTimers()
     vi.clearAllMocks()
-    // Clean up any per-test mock-client override so it can't leak into
-    // the next test.
-    ;(globalThis as any).__nextClientOverride = undefined
   })
 
   describe('init / lifecycle', () => {
@@ -305,37 +292,36 @@ describe('ConnectivityManager', () => {
       await m.execute('test', async () => { throw new TimeoutError('boom') })
       expect(m.getState()).toBe('degraded')
 
-      // Probe builds a fresh August client. The default mock makes its
-      // .locks() resolve, so the probe will succeed without further setup.
+      // Probe calls resetTransport() on the existing client and then its
+      // .locks(). Default mock = locks resolves, so probe succeeds.
 
       // Advance time past the first backoff slot (~5s plus jitter).
       await vi.advanceTimersByTimeAsync(7_000)
 
-      // Probe success → adopt fresh client → healthy. onClientChanged fires
-      // a second time (initial build + post-probe adoption).
+      // Probe success → healthy. onClientChanged was called only once
+      // (at init). The resetTransport-based design does NOT swap the
+      // client instance on recovery; it just recycles its transport.
       expect(m.getState()).toBe('healthy')
-      expect(onClientChanged).toHaveBeenCalledTimes(2)
+      expect(onClientChanged).toHaveBeenCalledTimes(1)
     })
 
     it('escalates from degraded to offline when probe fails, with longer backoff', async () => {
       const m = new ConnectivityManager(makeLog(), fakeCredentials)
       await m.init()
+      const client = m.getClient() as any
 
       const { TimeoutError } = await import('august-yale')
+
+      // Make the existing client's .locks() always fail. With the
+      // resetTransport-based design, probes reuse this client, so a
+      // single mockImplementation is sufficient for every probe attempt.
+      client.locks = vi.fn().mockImplementation(() => new Promise((_resolve, reject) => {
+        setTimeout(() => reject(new TimeoutError('still down')), 100)
+      }))
+
+      // Trigger degraded.
       await m.execute('test', async () => { throw new TimeoutError('boom') })
       expect(m.getState()).toBe('degraded')
-
-      // Override the NEXT (and all subsequent) clients built during this
-      // test so their .locks() rejects. __sticky keeps the override active
-      // across multiple probe attempts; without it, only the first probe
-      // would fail and the next would succeed against a default-mock
-      // client, recovering before we observe offline.
-      ;(globalThis as any).__nextClientOverride = {
-        __sticky: true,
-        locks: vi.fn().mockImplementation(() => new Promise((_resolve, reject) => {
-          setTimeout(() => reject(new TimeoutError('still down')), 100)
-        })),
-      }
 
       // Advance past first backoff + probe timeout.
       await vi.advanceTimersByTimeAsync(15_000)
@@ -367,71 +353,72 @@ describe('ConnectivityManager', () => {
       expect(m.getState()).toBe('healthy')
     })
 
-    it('probes use a FRESH client, not the existing (possibly-stale) one', async () => {
-      // This is the regression test for the production bug: the previous
-      // implementation probed against `this.client`, which kept failing
-      // on stale sockets even after the network had recovered. The
-      // PubNub-triggered immediate probe couldn't help because it used
-      // the same stale Agent.
+    it('probes call resetTransport() on the existing client (sheds stale sockets)', async () => {
+      // Regression test for the production bug: the original
+      // implementation probed against the existing client without
+      // resetting its socket pool. The pool kept stale half-open sockets
+      // from before the outage, probes failed on those sockets, system
+      // stayed offline.
       //
-      // Verify: when the existing client's .locks() would fail but a
-      // freshly-built client's .locks() succeeds, the probe still
-      // recovers the system to healthy.
-      const onClientChanged = vi.fn()
-      const m = new ConnectivityManager(makeLog(), fakeCredentials, onClientChanged)
+      // The fix: probe still uses the existing client (so we keep auth
+      // state), but resetTransport() is called first to throw away the
+      // dispatcher and its stale connections. New transport, same auth.
+      const m = new ConnectivityManager(makeLog(), fakeCredentials)
       await m.init()
-      const initialClient = m.getClient() as any
+      const client = m.getClient() as any
 
-      // Make the EXISTING client's .locks() reject, simulating a stale
-      // Agent. If the probe were running against `this.client`, it
-      // would fail and the system would stay offline.
+      // Sanity: the mock client has a resetTransport method.
+      expect(typeof client.resetTransport).toBe('function')
+
+      // Trigger degraded.
       const { TimeoutError } = await import('august-yale')
-      initialClient.locks = vi.fn().mockImplementation(() =>
-        new Promise((_resolve, reject) => setTimeout(() => reject(new TimeoutError('stale')), 100)),
-      )
+      await m.execute('test', async () => { throw new TimeoutError('boom') })
+      expect(m.getState()).toBe('degraded')
+
+      // Advance past the first backoff: probe runs, default mock has
+      // .locks() resolving, recovery completes.
+      await vi.advanceTimersByTimeAsync(7_000)
+      expect(m.getState()).toBe('healthy')
+
+      // The probe must have called resetTransport on the existing
+      // client. This is the structural assertion that locks in the fix.
+      expect(client.resetTransport).toHaveBeenCalled()
+      // The same client instance is still in place (we did NOT
+      // construct a new client — this distinguishes the resetTransport
+      // approach from the previous fresh-client approach).
+      expect(m.getClient()).toBe(client)
+    })
+
+    it('failed probe leaves the existing client in place (no leak, no rotation)', async () => {
+      // With resetTransport(), failed probes don't construct a temp
+      // client, so there's nothing to leak. The existing client stays
+      // the current client throughout the offline period — only its
+      // transport gets recycled, not the August instance itself.
+      const m = new ConnectivityManager(makeLog(), fakeCredentials)
+      await m.init()
+      const client = m.getClient() as any
+
+      const { TimeoutError } = await import('august-yale')
+
+      // Make the client's .locks() always fail.
+      client.locks = vi.fn().mockImplementation(() => new Promise((_, reject) =>
+        setTimeout(() => reject(new TimeoutError('still down')), 100),
+      ))
 
       // Trigger degraded.
       await m.execute('test', async () => { throw new TimeoutError('boom') })
       expect(m.getState()).toBe('degraded')
 
-      // Advance: probe builds a NEW client (default mock = locks resolves)
-      // → succeeds → adopt → healthy. The initialClient.locks rejection
-      // is irrelevant because the probe never calls it.
-      await vi.advanceTimersByTimeAsync(7_000)
-      expect(m.getState()).toBe('healthy')
-
-      // The current client should be a different instance.
-      expect(m.getClient()).not.toBe(initialClient)
-      // The old client got destroyed.
-      expect(initialClient.destroy).toHaveBeenCalled()
-    })
-
-    it('failed probe destroys the temporary client (no Agent leak)', async () => {
-      const m = new ConnectivityManager(makeLog(), fakeCredentials)
-      await m.init()
-
-      const { TimeoutError } = await import('august-yale')
-      await m.execute('test', async () => { throw new TimeoutError('boom') })
-      expect(m.getState()).toBe('degraded')
-
-      // Override probe's fresh client so its .locks() rejects AND
-      // capture its destroy mock. __sticky so any retried probe also
-      // fails (we want to verify destroy is called on the failing
-      // probe's client, not test recovery).
-      const probeDestroy = vi.fn()
-      ;(globalThis as any).__nextClientOverride = {
-        __sticky: true,
-        destroy: probeDestroy,
-        locks: vi.fn().mockImplementation(() => new Promise((_, reject) =>
-          setTimeout(() => reject(new TimeoutError('still down')), 100),
-        )),
-      }
-
+      // Advance past first probe → offline.
       await vi.advanceTimersByTimeAsync(15_000)
       expect(m.getState()).toBe('offline')
-      // Probe's fresh client must be destroyed; otherwise we'd leak
-      // an Agent on every failed probe attempt.
-      expect(probeDestroy).toHaveBeenCalled()
+
+      // The existing client is still the current client; nothing got
+      // destroyed or replaced.
+      expect(m.getClient()).toBe(client)
+      expect(client.destroy).not.toHaveBeenCalled()
+      // resetTransport was called for each probe attempt.
+      expect(client.resetTransport).toHaveBeenCalled()
     })
   })
 
@@ -445,16 +432,18 @@ describe('ConnectivityManager', () => {
       await m.execute('test', async () => { throw new TimeoutError('boom') })
       expect(m.getState()).toBe('degraded')
 
-      // PubNub reconnect → immediate probe. Default mock has the fresh
-      // client's .locks() resolving, so the probe succeeds.
+      // PubNub reconnect → immediate probe. Default mock has .locks()
+      // resolving, so the probe (which calls resetTransport on the
+      // existing client and then locks()) succeeds.
       m.onPubNubReconnect()
 
       // Probe runs synchronously inside onPubNubReconnect's microtask;
       // need to flush promises but no timer advance required.
       await vi.runAllTimersAsync()
       expect(m.getState()).toBe('healthy')
-      // Initial build + adoption-of-fresh-client after successful probe.
-      expect(onClientChanged).toHaveBeenCalledTimes(2)
+      // onClientChanged was only called once (at init). Recovery via
+      // resetTransport does not swap the client instance.
+      expect(onClientChanged).toHaveBeenCalledTimes(1)
     })
 
     it('is a no-op when already healthy', async () => {
@@ -542,23 +531,24 @@ describe('ConnectivityManager', () => {
       const log = makeLog()
       const m = new ConnectivityManager(log, fakeCredentials)
       await m.init()
+      const client = m.getClient() as any
 
       const { TimeoutError } = await import('august-yale')
-      await m.execute('test', async () => { throw new TimeoutError('boom') })
 
-      // Make probes fail forever — every fresh client's .locks() rejects.
-      // __sticky keeps the override active across multiple probe attempts
-      // so we can stay in offline state long enough for the heartbeat.
-      ;(globalThis as any).__nextClientOverride = {
-        __sticky: true,
-        locks: vi.fn().mockImplementation(() => new Promise((_resolve, reject) =>
-          setTimeout(() => reject(new TimeoutError('still down')), 100),
-        )),
-      }
+      // Make every probe fail by making the existing client's .locks
+      // always reject. With the resetTransport-based design, probes
+      // reuse this client across attempts, so a single mockImplementation
+      // covers every probe in the offline period.
+      client.locks = vi.fn().mockImplementation(() => new Promise((_resolve, reject) =>
+        setTimeout(() => reject(new TimeoutError('still down')), 100),
+      ))
+
+      // Trigger degraded.
+      await m.execute('test', async () => { throw new TimeoutError('boom') })
 
       // Drive past first probe so we land in offline.
       await vi.advanceTimersByTimeAsync(15_000)
-      return { m, log }
+      return { m, log, client }
     }
 
     it('emits a heartbeat after one hour of being offline', async () => {
@@ -581,10 +571,10 @@ describe('ConnectivityManager', () => {
     })
 
     it('stops emitting heartbeats after recovery', async () => {
-      const { m, log } = await getOfflineWithLog()
+      const { m, log, client } = await getOfflineWithLog()
 
-      // Allow recovery on the next probe by clearing any pending override.
-      ;(globalThis as any).__nextClientOverride = undefined
+      // Allow recovery on the next probe by making .locks resolve again.
+      client.locks = vi.fn().mockResolvedValue({})
 
       // Skip ahead enough for a probe to fire and succeed.
       await vi.advanceTimersByTimeAsync(60 * 1000)

--- a/test/connectivity-manager.test.ts
+++ b/test/connectivity-manager.test.ts
@@ -57,12 +57,14 @@ vi.mock('august-yale', () => {
     }
   }
   // Each new August() returns a unique object so tests can assert which
-  // client is being used (initial vs. rebuilt).
+  // client is being used (initial vs. rebuilt). Tests can also override
+  // the methods of the NEXT client to be built by setting fields on
+  // `nextClientOverride`. After one use the override is cleared.
   let nextId = 0
   // eslint-disable-next-line prefer-arrow-callback
   const MockAugust = vi.fn().mockImplementation(function () {
     const id = ++nextId
-    return {
+    const base: any = {
       _id: id,
       details: vi.fn().mockResolvedValue({ ok: true }),
       locks: vi.fn().mockResolvedValue({}),
@@ -71,6 +73,17 @@ vi.mock('august-yale', () => {
       destroy: vi.fn(),
       end: vi.fn(),
     }
+    const override = (globalThis as any).__nextClientOverride
+    if (override) {
+      Object.assign(base, override)
+      // Stickiness: if the override has __sticky set, preserve it across
+      // multiple new August() calls. Used by the heartbeat tests where
+      // every probe in a sequence should fail.
+      if (!override.__sticky) {
+        ;(globalThis as any).__nextClientOverride = undefined
+      }
+    }
+    return base
   })
   return {
     default: MockAugust,
@@ -108,6 +121,9 @@ describe('ConnectivityManager', () => {
   afterEach(() => {
     vi.useRealTimers()
     vi.clearAllMocks()
+    // Clean up any per-test mock-client override so it can't leak into
+    // the next test.
+    ;(globalThis as any).__nextClientOverride = undefined
   })
 
   describe('init / lifecycle', () => {
@@ -282,7 +298,6 @@ describe('ConnectivityManager', () => {
       const onClientChanged = vi.fn()
       const m = new ConnectivityManager(makeLog(), fakeCredentials, onClientChanged)
       await m.init()
-      const client = m.getClient() as any
       expect(onClientChanged).toHaveBeenCalledTimes(1)
 
       // Network failure: degrades and schedules probe.
@@ -290,13 +305,14 @@ describe('ConnectivityManager', () => {
       await m.execute('test', async () => { throw new TimeoutError('boom') })
       expect(m.getState()).toBe('degraded')
 
-      // Probe will call client.locks() — ensure it succeeds.
-      client.locks.mockResolvedValue({})
+      // Probe builds a fresh August client. The default mock makes its
+      // .locks() resolve, so the probe will succeed without further setup.
 
       // Advance time past the first backoff slot (~5s plus jitter).
       await vi.advanceTimersByTimeAsync(7_000)
 
-      // Probe success → rebuild + healthy. onClientChanged fires again.
+      // Probe success → adopt fresh client → healthy. onClientChanged fires
+      // a second time (initial build + post-probe adoption).
       expect(m.getState()).toBe('healthy')
       expect(onClientChanged).toHaveBeenCalledTimes(2)
     })
@@ -304,16 +320,22 @@ describe('ConnectivityManager', () => {
     it('escalates from degraded to offline when probe fails, with longer backoff', async () => {
       const m = new ConnectivityManager(makeLog(), fakeCredentials)
       await m.init()
-      const client = m.getClient() as any
 
       const { TimeoutError } = await import('august-yale')
       await m.execute('test', async () => { throw new TimeoutError('boom') })
       expect(m.getState()).toBe('degraded')
 
-      // Probe will fail (locks() rejects with timeout).
-      client.locks.mockImplementation(() => new Promise((_resolve, reject) => {
-        setTimeout(() => reject(new TimeoutError('still down')), 100)
-      }))
+      // Override the NEXT (and all subsequent) clients built during this
+      // test so their .locks() rejects. __sticky keeps the override active
+      // across multiple probe attempts; without it, only the first probe
+      // would fail and the next would succeed against a default-mock
+      // client, recovering before we observe offline.
+      ;(globalThis as any).__nextClientOverride = {
+        __sticky: true,
+        locks: vi.fn().mockImplementation(() => new Promise((_resolve, reject) => {
+          setTimeout(() => reject(new TimeoutError('still down')), 100)
+        })),
+      }
 
       // Advance past first backoff + probe timeout.
       await vi.advanceTimersByTimeAsync(15_000)
@@ -344,6 +366,73 @@ describe('ConnectivityManager', () => {
       expect(result).toBe('recovered')
       expect(m.getState()).toBe('healthy')
     })
+
+    it('probes use a FRESH client, not the existing (possibly-stale) one', async () => {
+      // This is the regression test for the production bug: the previous
+      // implementation probed against `this.client`, which kept failing
+      // on stale sockets even after the network had recovered. The
+      // PubNub-triggered immediate probe couldn't help because it used
+      // the same stale Agent.
+      //
+      // Verify: when the existing client's .locks() would fail but a
+      // freshly-built client's .locks() succeeds, the probe still
+      // recovers the system to healthy.
+      const onClientChanged = vi.fn()
+      const m = new ConnectivityManager(makeLog(), fakeCredentials, onClientChanged)
+      await m.init()
+      const initialClient = m.getClient() as any
+
+      // Make the EXISTING client's .locks() reject, simulating a stale
+      // Agent. If the probe were running against `this.client`, it
+      // would fail and the system would stay offline.
+      const { TimeoutError } = await import('august-yale')
+      initialClient.locks = vi.fn().mockImplementation(() =>
+        new Promise((_resolve, reject) => setTimeout(() => reject(new TimeoutError('stale')), 100)),
+      )
+
+      // Trigger degraded.
+      await m.execute('test', async () => { throw new TimeoutError('boom') })
+      expect(m.getState()).toBe('degraded')
+
+      // Advance: probe builds a NEW client (default mock = locks resolves)
+      // → succeeds → adopt → healthy. The initialClient.locks rejection
+      // is irrelevant because the probe never calls it.
+      await vi.advanceTimersByTimeAsync(7_000)
+      expect(m.getState()).toBe('healthy')
+
+      // The current client should be a different instance.
+      expect(m.getClient()).not.toBe(initialClient)
+      // The old client got destroyed.
+      expect(initialClient.destroy).toHaveBeenCalled()
+    })
+
+    it('failed probe destroys the temporary client (no Agent leak)', async () => {
+      const m = new ConnectivityManager(makeLog(), fakeCredentials)
+      await m.init()
+
+      const { TimeoutError } = await import('august-yale')
+      await m.execute('test', async () => { throw new TimeoutError('boom') })
+      expect(m.getState()).toBe('degraded')
+
+      // Override probe's fresh client so its .locks() rejects AND
+      // capture its destroy mock. __sticky so any retried probe also
+      // fails (we want to verify destroy is called on the failing
+      // probe's client, not test recovery).
+      const probeDestroy = vi.fn()
+      ;(globalThis as any).__nextClientOverride = {
+        __sticky: true,
+        destroy: probeDestroy,
+        locks: vi.fn().mockImplementation(() => new Promise((_, reject) =>
+          setTimeout(() => reject(new TimeoutError('still down')), 100),
+        )),
+      }
+
+      await vi.advanceTimersByTimeAsync(15_000)
+      expect(m.getState()).toBe('offline')
+      // Probe's fresh client must be destroyed; otherwise we'd leak
+      // an Agent on every failed probe attempt.
+      expect(probeDestroy).toHaveBeenCalled()
+    })
   })
 
   describe('onPubNubReconnect — fast recovery', () => {
@@ -351,20 +440,20 @@ describe('ConnectivityManager', () => {
       const onClientChanged = vi.fn()
       const m = new ConnectivityManager(makeLog(), fakeCredentials, onClientChanged)
       await m.init()
-      const client = m.getClient() as any
 
       const { TimeoutError } = await import('august-yale')
       await m.execute('test', async () => { throw new TimeoutError('boom') })
       expect(m.getState()).toBe('degraded')
 
-      client.locks.mockResolvedValue({})
+      // PubNub reconnect → immediate probe. Default mock has the fresh
+      // client's .locks() resolving, so the probe succeeds.
       m.onPubNubReconnect()
 
       // Probe runs synchronously inside onPubNubReconnect's microtask;
       // need to flush promises but no timer advance required.
       await vi.runAllTimersAsync()
       expect(m.getState()).toBe('healthy')
-      // Initial build + rebuild after successful probe.
+      // Initial build + adoption-of-fresh-client after successful probe.
       expect(onClientChanged).toHaveBeenCalledTimes(2)
     })
 
@@ -444,6 +533,68 @@ describe('ConnectivityManager', () => {
       const { TimeoutError } = await import('august-yale')
       await m.execute('test', async () => { throw new TimeoutError('boom') })
       expect(good).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('offline heartbeat', () => {
+    // Helper: drive the manager into offline state and capture the log.
+    async function getOfflineWithLog() {
+      const log = makeLog()
+      const m = new ConnectivityManager(log, fakeCredentials)
+      await m.init()
+
+      const { TimeoutError } = await import('august-yale')
+      await m.execute('test', async () => { throw new TimeoutError('boom') })
+
+      // Make probes fail forever — every fresh client's .locks() rejects.
+      // __sticky keeps the override active across multiple probe attempts
+      // so we can stay in offline state long enough for the heartbeat.
+      ;(globalThis as any).__nextClientOverride = {
+        __sticky: true,
+        locks: vi.fn().mockImplementation(() => new Promise((_resolve, reject) =>
+          setTimeout(() => reject(new TimeoutError('still down')), 100),
+        )),
+      }
+
+      // Drive past first probe so we land in offline.
+      await vi.advanceTimersByTimeAsync(15_000)
+      return { m, log }
+    }
+
+    it('emits a heartbeat after one hour of being offline', async () => {
+      const { log } = await getOfflineWithLog()
+
+      // Less than an hour: no heartbeat yet.
+      await vi.advanceTimersByTimeAsync(30 * 60_000)
+      const beforeHour = log._calls.filter(c => c.msg.includes('still offline')).length
+      expect(beforeHour).toBe(0)
+
+      // Past one hour: heartbeat fires. Probes are still failing in the
+      // background, so we filter for the heartbeat-specific message.
+      await vi.advanceTimersByTimeAsync(35 * 60_000)
+      const afterHour = log._calls.filter(c => c.msg.includes('still offline')).length
+      expect(afterHour).toBeGreaterThan(0)
+      // Heartbeat content includes attempt count and last failure.
+      const heartbeatLine = log._calls.find(c => c.msg.includes('still offline'))
+      expect(heartbeatLine?.msg).toMatch(/\d+ probe attempts?/)
+      expect(heartbeatLine?.msg).toContain('last failure')
+    })
+
+    it('stops emitting heartbeats after recovery', async () => {
+      const { m, log } = await getOfflineWithLog()
+
+      // Allow recovery on the next probe by clearing any pending override.
+      ;(globalThis as any).__nextClientOverride = undefined
+
+      // Skip ahead enough for a probe to fire and succeed.
+      await vi.advanceTimersByTimeAsync(60 * 1000)
+      expect(m.getState()).toBe('healthy')
+
+      const beforeIdle = log._calls.filter(c => c.msg.includes('still offline')).length
+      // Advance two more hours — should NOT see new heartbeat lines.
+      await vi.advanceTimersByTimeAsync(2 * 60 * 60_000)
+      const afterIdle = log._calls.filter(c => c.msg.includes('still offline')).length
+      expect(afterIdle).toBe(beforeIdle)
     })
   })
 })


### PR DESCRIPTION
## :recycle: Current situation

The previous probe-fix in this repo shipped with a
"fresh client per probe attempt" design: each probe constructed a
new `August` instance, used its `.locks()` for the probe, and on
success adopted that fresh instance as the current client.

That works but has two costs:

1. **Forced re-authentication on every probe.** A new August
   instance has no cached session token, so its first call goes
   through `POST /session` before the actual probe request. On a
   still-flaky network the auth round-trip itself can fail,
   leaving the probe in a worse state than necessary. We lose the
   benefit of having a healthy session.

2. **Test-infrastructure complexity.** Per-probe client
   construction forced a `globalThis.__nextClientOverride` hook
   (with optional `__sticky` flag) so tests could control which
   freshly-built clients failed and which succeeded. That's a
   global escape hatch — a code smell the previous commit comment
   already noted.

august-yale#1.2.1 adds an `August.resetTransport()` method that
throws away the dispatcher and creates a fresh one **without
losing auth state**. That makes a cleaner design possible.

## :bulb: Proposed solution

Replace "build fresh client" with "reset the existing client's
transport":

```ts
private async runProbe(): Promise<void> {
  this.probeAttempts++
  // ... no-client guard ...

  // Reset transport BEFORE probing — sheds stale sockets without
  // re-authenticating. The next request goes out on a clean
  // connection pool but reuses the cached session token.
  this.client!.resetTransport()

  try {
    await Promise.race([this.client!.locks(), /* probe timeout */])
    this.transitionTo('healthy')
    // No client swap on recovery — same instance, fresh transport.
  } catch (e) {
    if (this.state !== 'offline') {
      this.transitionTo('offline')
    }
    this.scheduleProbe()
    // No temporary client to clean up.
  }
}
```

Two simplifications fall out:

- Successful probe doesn't need to swap `this.client` or destroy
  an old one. The same August instance stays in place, just with
  a fresh dispatcher. `onClientChanged` is no longer fired on
  recovery (it still fires at init and on auth-driven rebuilds).
- Failed probe doesn't need to clean up a temp client.

And on the test side, since probes reuse the existing client across
attempts, tests can monkey-patch the existing client's `.locks()`
directly to simulate a series of failures. No more `globalThis`
hooks. The `__nextClientOverride` and `__sticky` mechanism is
deleted entirely.

## :gear: Release Notes

Connectivity recovery after transient network outages no longer
pays an auth round-trip on every probe attempt. On networks where
the August API is reachable but the session endpoint is slow, this
is a meaningful win for recovery time.

No user-visible behavior change other than faster recovery and
slightly fewer log lines (no per-probe "rebuilt client" message,
because there's no rebuild — just transport reset).

Bumps `august-yale` to `^1.3.0` (the version that introduces
`resetTransport`). Adjust if the maintainer publishes under a
different version.

## :heavy_plus_sign: Additional Information

### Testing

90/90 still passing.

### Reviewer Nudging

