### PR TITLE
feat(matter): expose lock battery via a PowerSource cluster

### DIFF
--- a/src/platform.matter.ts
+++ b/src/platform.matter.ts
@@ -161,6 +161,21 @@ export class AugustMatterPlatform extends AugustPlatform {
           actuatorEnabled: true,
           operatingMode: 0, // 0 = Normal
         },
+        // PowerSource (Battery feature) so the lock battery reaches Matter
+        // controllers (e.g. Home Assistant), matching what the HAP Battery
+        // service already exposes. Homebridge composes PowerSourceServer
+        // .with('Battery') when batPercentRemaining/batChargeLevel are present.
+        // Placeholder values until the first poll pushes real ones (below);
+        // batPercentRemaining is Matter half-percent (0..200).
+        powerSource: {
+          status: 1, // PowerSourceStatus.Active
+          order: 0,
+          description: 'Battery',
+          batReplaceability: 2, // UserReplaceable (AA cells)
+          batReplacementNeeded: false,
+          batChargeLevel: 0, // BatChargeLevel.Ok
+          batPercentRemaining: 200, // 100% until first poll
+        },
       },
       handlers: {
         doorLock: {
@@ -322,6 +337,25 @@ export class AugustMatterPlatform extends AugustPlatform {
       return
     }
     const details = lockDetails as any
+
+    // Battery -> PowerSource. August reports `battery` as a 0..1 fraction;
+    // Matter batPercentRemaining is half-percent (0..200). Mirror the HAP
+    // Battery service's <15% low threshold. The /locks/{id} detail carries
+    // `battery` even when it has no LockStatus.state (lock state is driven by
+    // PubNub events / a separate status call), so push the battery BEFORE the
+    // lock-state guard below — otherwise a stateless detail response, which is
+    // the norm for this endpoint, drops the battery update entirely.
+    if (typeof details.battery === 'number') {
+      const pct = Math.min(Math.max(details.battery, 0), 1)
+      const low = pct < 0.15
+      await matterApi.updateAccessoryState(uuid, 'powerSource', {
+        batPercentRemaining: Math.round(pct * 200),
+        batChargeLevel: pct < 0.10 ? 2 : low ? 1 : 0, // Critical / Warning / Ok
+        batReplacementNeeded: low,
+      })
+      await this.debugLog(`Matter: Poll updated battery to ${Math.round(pct * 100)}% for ${device.LockName}`)
+    }
+
     if (!details?.LockStatus?.state) {
       return
     }

--- a/test/platform.matter.test.ts
+++ b/test/platform.matter.test.ts
@@ -657,4 +657,87 @@ describe('augustMatterPlatform', () => {
       expect(swept).not.toContain(migrated)
     })
   })
+
+  describe('fetchAndUpdateMatterLockState (battery → PowerSource)', () => {
+    // Install a stub connectivity manager whose execute() runs the poll fn
+    // against a fake august client, matching the suite's conventions.
+    function withDetails(p: any, detail: any) {
+      const client = { details: vi.fn().mockResolvedValue(detail) }
+      p.connectivity = { execute: vi.fn(async (_label: string, fn: (c: any) => Promise<any>) => fn(client)) }
+      return client
+    }
+
+    it('pushes the battery level to the PowerSource cluster on poll', async () => {
+      platform = new AugustMatterPlatform(mockLog, mockConfig, mockApi)
+      withDetails(platform, { battery: 0.53 })
+
+      await (platform as any).fetchAndUpdateMatterLockState(
+        { lockId: 'lock-1', LockName: 'Front Door' } as any,
+        'matter-uuid-lock-1',
+        mockMatterApi,
+      )
+
+      expect(mockMatterApi.updateAccessoryState).toHaveBeenCalledWith(
+        'matter-uuid-lock-1',
+        'powerSource',
+        expect.objectContaining({
+          batPercentRemaining: 106, // round(0.53 * 200)
+          batChargeLevel: 0, // OK
+          batReplacementNeeded: false,
+        }),
+      )
+    })
+
+    it('pushes the battery even when the detail carries no lock state, and flags a low battery', async () => {
+      platform = new AugustMatterPlatform(mockLog, mockConfig, mockApi)
+      withDetails(platform, { battery: 0.08 }) // low, and no LockStatus.state at all
+
+      await (platform as any).fetchAndUpdateMatterLockState(
+        { lockId: 'lock-2', LockName: 'Kitchen Door' } as any,
+        'matter-uuid-lock-2',
+        mockMatterApi,
+      )
+
+      // Regression guard: a stateless detail response — the norm for this
+      // endpoint — must not drop the battery update.
+      expect(mockMatterApi.updateAccessoryState).toHaveBeenCalledWith(
+        'matter-uuid-lock-2',
+        'powerSource',
+        expect.objectContaining({
+          batPercentRemaining: 16, // round(0.08 * 200)
+          batChargeLevel: 2, // Critical (<10%)
+          batReplacementNeeded: true, // <15%
+        }),
+      )
+      // ...and it must not push a doorLock state it doesn't have.
+      expect(mockMatterApi.updateAccessoryState).not.toHaveBeenCalledWith(
+        'matter-uuid-lock-2',
+        'doorLock',
+        expect.anything(),
+      )
+    })
+
+    it('leaves PowerSource untouched when the detail has no battery field', async () => {
+      platform = new AugustMatterPlatform(mockLog, mockConfig, mockApi)
+      withDetails(platform, { LockStatus: { state: { locked: true } } }) // no battery
+
+      await (platform as any).fetchAndUpdateMatterLockState(
+        { lockId: 'lock-3', LockName: 'Guest Door' } as any,
+        'matter-uuid-lock-3',
+        mockMatterApi,
+      )
+
+      expect(mockMatterApi.updateAccessoryState).not.toHaveBeenCalledWith(
+        'matter-uuid-lock-3',
+        'powerSource',
+        expect.anything(),
+      )
+      // lock state is present, so the doorLock update still happens as before.
+      expect(mockMatterApi.updateAccessoryState).toHaveBeenCalledWith(
+        'matter-uuid-lock-3',
+        'doorLock',
+        expect.objectContaining({ lockState: 1 }),
+      )
+    })
+  })
 })


### PR DESCRIPTION
## :recycle: Current situation

The Matter DoorLock accessory exposes no battery. August already reports a
`battery` level (0..1) in the lock detail, and the HAP side surfaces it, but
nothing is put on the Matter endpoint — so Matter controllers (e.g. Home
Assistant) show no battery for the locks.

## :bulb: Proposed solution

Attach a `PowerSource` (Battery feature) cluster to the Matter DoorLock
accessory and update it from the poll: map August's 0..1 `battery` to Matter's
half-percent `batPercentRemaining` (0..200), with `batChargeLevel` /
`batReplacementNeeded` mirroring the HAP Battery service's <15% low / <10%
critical thresholds.

The August `/locks/{id}` detail carries `battery` even when it has no
`LockStatus.state` (lock state is driven by PubNub events / a separate status
call), so the battery is pushed **before** the lock-state guard — otherwise the
common stateless detail response drops it.

Note: composing this over Matter also requires the Homebridge core fix that composes `PowerSource` for non-RoboticVacuumCleaner device types ([homebridge/homebridge#3968](https://github.com/homebridge/homebridge/pull/3968)).

Until that lands in a release, core silently drops the cluster — so this change is a safe no-op on current core and lights up once the core fix is released.

## :gear: Release Notes

August lock battery level is now exposed over Matter (a battery entity on Matter
controllers such as Home Assistant), matching what HAP already provides. No
config changes; no effect on accessories/paths that don't poll battery.

## :heavy_plus_sign: Additional Information

Verified end-to-end on a real bridge (3 August locks): the commissioned node's
lock endpoints gain cluster `0x2F` with the Battery feature and HA shows a
working battery sensor per lock (e.g. 53% / 93% / 27%).

### Testing

Added three cases to `test/platform.matter.test.ts` around
`fetchAndUpdateMatterLockState`: (1) a normal battery push
(`0.53 → batPercentRemaining 106, level OK`); (2) the stateless-detail
regression — a detail with `battery` but no `LockStatus.state` still pushes the
battery (and flags low/critical at 8%), and does *not* push a doorLock state it
doesn't have; (3) a detail with no `battery` field leaves `PowerSource` untouched
while the lock state still updates. Existing tests unchanged (93/93 pass).

### Reviewer Nudging

`src/platform.matter.ts` → `fetchAndUpdateMatterLockState`: the battery block and
its placement before the `!details?.LockStatus?.state` guard are the whole
change (plus the cluster declaration in the accessory definition).